### PR TITLE
Refactor HiFi-analog.conf to use postmixer

### DIFF
--- a/fix/ucm2/HiFi-analog.conf
+++ b/fix/ucm2/HiFi-analog.conf
@@ -121,7 +121,7 @@ If.spk {
 			PlaybackPriority 100
 			PlaybackPCM "hw:${CardId}"
 			PlaybackMixerElem "Speaker"
-			PlaybackMasterElem "Speaker"
+			PlaybackMasterElem "Master"
 			PlaybackVolume "Speaker Playback Volume"
 			PlaybackSwitch "Speaker Playback Switch"
 		}


### PR DESCRIPTION
Check for postmixer instead of model-specific code as discussed in issue #19