### PR TITLE
Fix UCM2 configuration for newer ALSA versions

### DIFF
--- a/fix/ucm2/HiFi-analog.conf
+++ b/fix/ucm2/HiFi-analog.conf
@@ -2,6 +2,7 @@
 
 Define.LineDevice ""
 Define.hpvol "Headphone"
+Define.spkvol "Speaker"
 Define.hpjack "Headphone Jack"
 Define.loctl "Line"
 Define.lovol "Line"


### PR DESCRIPTION
Add missing Define.spkvol variable to fix alsaucm error with recent ALSA UCM2 releases.

The Intel/sof-hda-dsp/HiFi-sof.conf file (introduced in alsa-ucm-conf ~1.2.12+) checks for ${var:spkvol} but this variable was not defined in the original HiFi-analog.conf, causing alsaucm to fail with:

  variable '${var:spkvol}' is not defined in this context!

The upstream alsa-ucm-conf already includes this definition. This fix aligns with the current upstream version.

Tested on:
- Fedora 43 (6.18.5-200) with alsa-ucm 1.2.15.3
- Lenovo Legion Pro 7 16IAX10H