### PR TITLE
Add comprehensive Fedora kernel build guide with automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ Replace `your-root-partition-uuid` with your actual root partition UUID (find it
 
 **Note:** You must include `snd_intel_dspcfg.dsp_driver=3` in your kernel boot parameters.
 
+> **Looking for a complete Fedora guide with Secure Boot support?**
+> See the comprehensive [Fedora Kernel Build Guide](patch-kernel-fedora/FEDORA-BUILD-GUIDE.md) which covers building the Fedora kernel with native RPM packages, Secure Boot signing, and akmods integration for NVIDIA drivers. An [automation script](patch-kernel-fedora/automation/) is also available.
+
 </details>
 
 ## Step 8: Reboot into the Patched Kernel

--- a/patch-kernel-fedora/FEDORA-BUILD-GUIDE.md
+++ b/patch-kernel-fedora/FEDORA-BUILD-GUIDE.md
@@ -1,0 +1,1686 @@
+# Fedora Kernel 6.18.7 Build Guide with AW88399 Audio Patch
+
+> **Guide version**: Fedora Kernel 6.18.7-200.fc43.x86_64
+> **Compatibility**: ✅ All **6.18.x** versions are supported
+> **Date**: January 2026
+> **Secure Boot compatibility**: ✅ YES (manual kernel signing required – see Phase 8)
+
+> 📌 **Note**: This guide uses kernel version **6.18.7** as an example, but the instructions apply to **all Fedora 6.18.x kernels**. Simply adjust the version numbers in the commands to match your target version.
+
+⚠️ **IMPORTANT**: A kernel built using `fedpkg local` is **NOT** automatically signed for Secure Boot. You must manually sign the kernel with your MOK key (Phase 8) to keep Secure Boot enabled.
+
+---
+
+## Table of Contents
+
+### Main Phases
+
+1. [Introduction and benefits](#1-introduction-and-benefits)
+2. [Phase 1: Installing Fedora build tools](#phase-1--installing-fedora-build-tools)
+3. [Phase 2: Fetching Fedora kernel sources](#phase-2--fetching-fedora-kernel-sources)
+4. [Phase 3: Preparing the audio patch](#phase-3--preparing-the-audio-patch)
+5. [Phase 4: Modifying the kernel.spec file](#phase-4--modifying-the-kernelspec-file)
+6. [Phase 5: Configuring audio options](#phase-5--configuring-audio-options)
+7. [Phase 6: Kernel compilation](#phase-6--kernel-compilation)
+8. [Phase 7: Installing the generated RPMs](#phase-7--installing-the-generated-rpms)
+9. [Phase 8: Kernel signing for Secure Boot](#phase-8--kernel-signing-for-secure-boot) ⚠️ **CRITICAL if Secure Boot is enabled**
+10. [Phase 9: Bootloader configuration](#phase-9--bootloader-configuration)
+11. [Phase 10: NVIDIA modules and finalization](#phase-10--nvidia-modules-and-finalization) (optional – akmods builds automatically)
+12. [Phase 11: Reboot and finalization](#phase-11--reboot-and-finalization)
+13. [Phase 12: Archiving and cleanup](#phase-12--archiving-and-cleanup-optional) (optional)
+
+---
+
+## 1. Introduction and Benefits
+
+### Why compile the Fedora kernel instead of the vanilla kernel?
+
+**Advantages of the Fedora kernel:**
+
+* ✅ **Secure Boot compatible**: Fedora-specific patches allow the use of custom MOK keys
+* ✅ **No manual module re-signing required**: kernel modules built by Fedora are already trusted under Secure Boot
+* ✅ **Native RPM packages**: clean installation and removal using `dnf`
+* ✅ **Native akmods integration**: proprietary drivers (NVIDIA, etc.) work out of the box
+* ✅ **Fedora patches included**: distribution-specific optimizations and fixes
+* ✅ **Robust build system**: `fedpkg` for reproducible builds
+
+> **📌 Kernel modules do NOT need to be manually re-signed** – modules built using Fedora’s kernel build system are already signed and trusted by the Fedora kernel under Secure Boot, thanks to Fedora’s lockdown and key-handling patches.
+
+---
+
+### Fedora Secure Boot handling: automatic MOK key integration
+
+Unlike the vanilla kernel, the Fedora kernel includes downstream patches that automatically load **Machine Owner Keys (MOK)** from UEFI NVRAM into the kernel keyring at boot time when Secure Boot is enabled. This allows:
+
+* ✅ Verification of kernel images signed with a user-managed MOK
+* ✅ Loading of third-party modules (e.g. NVIDIA) built and signed via `akmods`
+* ✅ Secure Boot to remain enabled without disabling kernel lockdown
+
+---
+
+### Why AW88399 support requires an out-of-tree patch
+
+**Awinic AW88399** amplifiers used in Lenovo Legion laptops rely on a **hybrid x86 audio architecture**:
+
+* **HDA (High Definition Audio)**: primary audio interface used by the Intel x86 audio stack
+* **I²C**: control bus used to manage the AW88399 smart amplifiers
+
+This design explains why:
+
+1. **The driver is implemented as an HDA smart codec (scodec)**: it integrates with the HDA subsystem while controlling the amplifiers over I²C
+2. **ASoC is not used**: unlike ARM/mobile platforms, Lenovo Legion systems rely on the legacy x86 HDA architecture
+3. **Upstream integration is slow**: the patch has existed since mid-2024 but has not yet been merged into mainline due to review and design concerns
+4. **This architecture was chosen by Lenovo**: likely to reduce BOM cost while still using modern smart amplifiers
+
+---
+
+### Guide Objective
+
+Rebuild the Fedora kernel **6.18.7-200.fc43.x86_64** with the required audio patch for **Awinic AW88399** amplifiers found on:
+
+* Lenovo Legion Pro 7i Gen 10 (16IAX10H) – Product: 83F5
+* Lenovo Legion Pro 7 Gen 10 (16AFR10H) – Product: 83RU
+* Lenovo Legion 5i Gen 9 (16IRX9)
+
+---
+
+## Phase 1: Installing Fedora Build Tools
+
+### 1.1 ▶️ Install core tools required for kernel compilation
+
+```bash
+sudo dnf install -y \
+    fedpkg \
+    fedora-packager \
+    rpm-build \
+    rpmdevtools \
+    git \
+    wget \
+    curl
+```
+
+> **Note**: This guide exclusively uses `fedpkg local`, which relies on `rpmbuild` for local kernel compilation.
+> No chroot-based or remote build systems (`mock`, `koji`) are used in this workflow.
+
+---
+
+### 1.2 ▶️ Install tools required for RPM building and Secure Boot
+
+```bash
+sudo dnf install -y \
+    pesign \
+    sbsigntools \
+    mokutil \
+    grubby \
+    dracut \
+    ccache
+```
+
+* `pesign` is used to manually sign the kernel for Secure Boot
+* `sbsigntools` is required for signing EFI binaries
+* `mokutil` manages Machine Owner Keys (MOK)
+* `grubby` updates bootloader entries
+* `dracut` generates the initramfs
+* `ccache` is optional but recommended to speed up rebuilds
+
+---
+
+### 1.3 ▶️ Configure pesign for Secure Boot
+
+> **📌 Official Fedora documentation**:
+> *Building a Custom Kernel – Secure Boot*
+> [https://docs.fedoraproject.org/en-US/quick-docs/kernel-build-custom/](https://docs.fedoraproject.org/en-US/quick-docs/kernel-build-custom/)
+
+```bash
+# Add the current user to the pesign user list
+sudo bash -c "echo $USER >> /etc/pesign/users"
+
+# Authorize access to the pesign daemon
+sudo /usr/libexec/pesign/pesign-authorize
+```
+
+This configuration allows the current user to sign kernel binaries using `pesign` **without requiring sudo for each signing operation**.
+
+---
+
+# Phase 2: Fetching Fedora Kernel Sources
+
+## 2.1 ▶️ Clone the Fedora kernel repository
+
+```bash
+# Create a working directory
+mkdir -p ~/fedora-kernel-build
+cd ~/fedora-kernel-build
+
+# Clone the Fedora kernel repository (all branches)
+fedpkg clone -a kernel
+
+# Enter the repository
+cd kernel
+```
+
+---
+
+## 2.2 ▶️ Select the Fedora 43 branch
+
+```bash
+# List available Fedora branches
+git branch -a | grep f4
+
+# Switch to the Fedora 43 branch
+git checkout f43
+
+# Verify
+git branch
+# Expected output:
+# * f43
+```
+
+---
+
+## 2.3 ▶️ Identify and check out the commit matching version 6.18.7-200
+
+### 2.3.1 Locate the exact kernel version
+
+```bash
+git log --oneline | grep "6.18.7-200"
+```
+
+**Expected example output:**
+
+```
+7ec2a9ad5 kernel-6.18.7-200
+```
+
+> **Note**: In this case, there is no dedicated Git tag for `6.18.7-200`.
+> The commit `7ec2a9ad5` corresponds exactly to this kernel release.
+
+---
+
+### 2.3.2 Create a local build branch from the exact commit
+
+⚠️ **CRITICAL**: `fedpkg` does **not** work reliably in a detached HEAD state.
+You **must** create a local branch from the target commit.
+
+```bash
+# Create a local build branch from the identified commit
+git checkout -b build-6.18.7-audio 7ec2a9ad5
+```
+
+**Expected message:**
+
+```
+Switched to a new branch 'build-6.18.7-audio'
+```
+
+> **Why a local branch is required**
+>
+> * `fedpkg` refuses to operate in detached HEAD mode (`Repo in inconsistent state`)
+> * A local branch allows `fedpkg local` to function normally
+> * The branch name is arbitrary but descriptive
+> * This branch is strictly local and must never be pushed upstream
+
+---
+
+### 2.3.3 Verify branch and commit state
+
+```bash
+# Verify that you are on the local branch
+git branch
+# Expected: * build-6.18.7-audio
+
+# Verify the current commit
+git log -1 --oneline
+# Expected:
+# 7ec2a9ad5 (HEAD -> build-6.18.7-audio) kernel-6.18.7-200
+```
+
+---
+
+### 2.3.4 Verify version information in `kernel.spec`
+
+```bash
+# Check version-related macros
+grep "^Version:" kernel.spec
+# Expected: Version: %{specrpmversion}
+
+grep "^%define specversion" kernel.spec
+# Expected: %define specversion 6.18.7
+
+grep "^%define pkgrelease" kernel.spec
+# Expected: %define pkgrelease 200
+
+grep "^Release:" kernel.spec
+# Expected: Release: %{specrpmrelease}%{?buildid}%{?dist}
+```
+
+---
+
+## 2.4 ▶️ Download kernel source archives
+
+```bash
+# Download all source archives declared in the spec file
+fedpkg sources
+
+# Verify downloaded archives
+ls -lh *.tar.xz
+ls -lh patch-*.patch
+```
+
+**Typical result for kernel 6.18.7:**
+
+```
+linux-6.18.7.tar.xz                    ~150M
+kernel-abi-stablelists-6.18.7.tar.xz   ~3K
+kernel-kabi-dw-6.18.7.tar.xz           ~1K
+patch-6.18-redhat.patch                ~60K
+```
+
+---
+
+## 2.5 ▶️ Install build dependencies
+
+```bash
+# Install all build dependencies required by kernel.spec
+sudo dnf builddep kernel.spec
+```
+
+This command installs all required compilers, build tools, and development libraries by resolving dependencies declared in `kernel.spec`.
+
+---
+
+## 2.6 ▶️ Inspect patches declared in `kernel.spec`
+
+```bash
+# List patches declared in the spec file
+grep "^Patch" kernel.spec
+```
+
+**Expected output for Fedora kernel 6.18.7:**
+
+```
+Patch1: patch-6.18-redhat.patch
+Patch999999: linux-kernel-test.patch
+```
+
+```bash
+# Count Patch declarations
+grep -c "^Patch" kernel.spec
+# Expected: 2
+```
+
+> Although only a small number of patches are declared,
+> `patch-6.18-redhat.patch` is a **consolidated downstream patch** containing many individual changes.
+
+```bash
+# Inspect the approximate number of modifications inside the consolidated patch
+grep -c "^diff --git" patch-6.18-redhat.patch
+# Expected: several dozen changes (exact number may vary between minor releases)
+```
+
+---
+
+# Phase 3: Preparing the Audio Patch
+
+## 3.1 ▶️ Retrieve the AW88399 audio patch
+
+```bash
+# Return to the parent working directory
+cd ~/fedora-kernel-build
+
+# Clone the audio fix repository
+git clone https://github.com/nadimkobeissi/16iax10h-linux-sound-saga.git
+
+# Copy the patch targeting Linux 6.18
+cp 16iax10h-linux-sound-saga/fix/patches/16iax10h-audio-linux-6.18.patch kernel/
+```
+
+---
+
+## 3.2 ▶️ Install the required firmware
+
+The patch requires the firmware file `aw88399_acf.bin` to be present at runtime.
+
+```bash
+# Check whether the firmware is already installed
+ls -la /lib/firmware/aw88399_acf.bin
+```
+
+If the file is missing:
+
+```bash
+# Install the firmware manually
+sudo cp ~/fedora-kernel-build/16iax10h-linux-sound-saga/fix/firmware/aw88399_acf.bin /lib/firmware/
+
+# Set correct permissions
+sudo chmod 644 /lib/firmware/aw88399_acf.bin
+
+# Verify
+ls -la /lib/firmware/aw88399_acf.bin
+```
+
+> **Note**: Firmware files are not signed and do not affect Secure Boot.
+> They are loaded by the kernel at runtime by the driver.
+
+---
+
+# Phase 4: Modifying the `kernel.spec` File
+
+## 4.1 📚 Understanding the structure of `kernel.spec`
+
+The `kernel.spec` file is the core of the RPM build process. It defines:
+
+* Kernel versions and releases
+* The list of patches to apply
+* Configuration options
+* Build instructions
+* Generated RPM packages
+
+---
+
+## 4.2 ▶️ Back up the original spec file
+
+```bash
+cd ~/fedora-kernel-build/kernel
+cp kernel.spec kernel.spec.orig
+```
+
+---
+
+## 4.3 📚 Understanding Fedora’s patch system (Important!)
+
+Fedora now uses a **consolidated patch system**:
+
+```bash
+# List patches declared in the spec file
+grep "^Patch" kernel.spec
+# Typical output for kernel 6.18.7:
+# Patch1: patch-6.18-redhat.patch      ← Fedora consolidated MEGA-PATCH
+# Patch999999: linux-kernel-test.patch ← Test patch (optional)
+```
+
+**Explanation:**
+
+* **Patch1** (`patch-6.18-redhat.patch`) contains **ALL Fedora downstream patches**, consolidated into a single file
+* For kernel 6.18.7, this patch contains ~44 individual changes (~51 KB)
+* The newer the kernel, the fewer differences there are compared to upstream
+
+```bash
+# Verify the consolidated patch
+ls -lh patch-6.18-redhat.patch
+# Expected: ~51K (for 6.18.7)
+# Count the number of modifications it contains
+grep -c "^diff --git" patch-6.18-redhat.patch
+# Expected: ~43 modifications
+```
+
+**Important**: Your audio patch must be added **after** the Fedora consolidated patch, using a high patch number to avoid conflicts.
+
+---
+
+## 4.4 ▶️ Adding the patch to `kernel.spec`
+
+You must make **three changes** to `kernel.spec`:
+
+1. **Declare the patch** (Patch section)
+2. **Apply the patch** (`%prep` section)
+3. **Define a build ID** to identify your custom build
+
+Two methods are available.
+
+---
+
+### 🚀 Method A: Automated script (recommended)
+
+Create and run the following script **as-is**:
+
+```bash
+cd ~/fedora-kernel-build/kernel
+cat > modify_kernel_spec.sh << 'EOF'
+#!/bin/bash
+SPEC_FILE="kernel.spec"
+PATCH_FILE="16iax10h-audio-linux-6.18.patch"
+BUILD_ID=".audio"
+# Backup
+cp "$SPEC_FILE" "${SPEC_FILE}.orig"
+echo "✓ Backup created: ${SPEC_FILE}.orig"
+# 1. Add patch declaration (after Patch999999)
+PATCH_LINE=$(grep -n "^Patch999999:" "$SPEC_FILE" | cut -d: -f1)
+sed -i "${PATCH_LINE}a Patch10000: ${PATCH_FILE}" "$SPEC_FILE"
+echo "✓ Patch declared: Patch10000: ${PATCH_FILE}"
+# 2. Add patch application (after linux-kernel-test.patch)
+APPLY_LINE=$(grep -n "ApplyOptionalPatch linux-kernel-test.patch" "$SPEC_FILE" | cut -d: -f1)
+sed -i "${APPLY_LINE}a ApplyOptionalPatch ${PATCH_FILE}" "$SPEC_FILE"
+echo "✓ Patch application added"
+# 3. Set buildid
+sed -i "s/^# define buildid .local$/%define buildid ${BUILD_ID}/" "$SPEC_FILE"
+echo "✓ BuildID set: ${BUILD_ID}"
+# Verification
+echo ""
+echo "=== Verification ==="
+echo "Declared patches:"
+grep "^Patch" "$SPEC_FILE" | tail -3
+echo ""
+echo "BuildID:"
+grep "define buildid" "$SPEC_FILE" | grep -v "^#"
+echo ""
+echo "Applied patches:"
+grep "ApplyOptionalPatch" "$SPEC_FILE" | grep -v "ApplyOptionalPatch()" | tail -3
+EOF
+
+chmod +x modify_kernel_spec.sh
+
+./modify_kernel_spec.sh
+```
+
+---
+
+### ✏️ Method B: Manual modification
+
+If you prefer to edit the file manually, apply the following three changes.
+
+**1. Declare the patch** (search for `Patch999999:`)
+
+```bash
+nano kernel.spec
+# Search (Ctrl+W): Patch999999
+# Add after this line:
+Patch10000: 16iax10h-audio-linux-6.18.patch
+```
+
+**2. Apply the patch** (search for `ApplyOptionalPatch linux-kernel-test.patch`)
+
+```bash
+# Search (Ctrl+W): ApplyOptionalPatch linux-kernel-test.patch
+# Add after this line:
+ApplyOptionalPatch 16iax10h-audio-linux-6.18.patch
+```
+
+**3. Define the build ID** (search for `# define buildid`)
+
+```bash
+# Search (Ctrl+W): # define buildid
+# Replace the line:
+# define buildid .local
+# With:
+%define buildid .audio
+```
+
+---
+
+## 4.5 ✅ Verifying the modifications
+
+Regardless of the method used, verify that everything is correct:
+
+```bash
+cd ~/fedora-kernel-build/kernel
+echo "=== 1. Declared patches ==="
+grep "^Patch" kernel.spec | tail -3
+echo -e "\n=== 2. BuildID ==="
+grep "define buildid" kernel.spec | grep -v "^#"
+echo -e "\n=== 3. Applied patches ==="
+grep "ApplyOptionalPatch" kernel.spec | grep -v "ApplyOptionalPatch()" | tail -3
+echo -e "\n=== 4. Patch file present ==="
+ls -lh 16iax10h-audio-linux-6.18.patch
+```
+
+**Expected result:**
+
+```
+Patch10000: 16iax10h-audio-linux-6.18.patch
+%define buildid .audio
+ApplyOptionalPatch 16iax10h-audio-linux-6.18.patch
+```
+
+✅ If these entries are present, you can proceed to the next phase.
+
+---
+
+# Phase 5: Configuring Audio Options
+
+## 5.1 📚 Why this step is required
+
+The **patch** added the **source code** for AW88399 support.
+However, this code will only be compiled if the corresponding **kernel configuration options** are explicitly enabled.
+
+Fedora’s kernel build system requires **all new configuration symbols introduced by a patch** to be defined in **all architecture config files** (x86_64, aarch64, ppc64le, etc.), otherwise the build fails.
+
+---
+
+## 5.2 ✅ Detecting required configuration options
+
+First, create a script to detect which options are already present and which must be added:
+
+```bash
+cd ~/fedora-kernel-build/kernel
+
+# Create the detection script
+cat > check-audio-options.sh << 'EOF'
+#!/bin/bash
+
+echo "=========================================="
+echo "  Detecting required audio options"
+echo "=========================================="
+echo ""
+
+# Options required by the audio patch
+REQUIRED_OPTIONS=(
+  "CONFIG_SND_HDA_SCODEC_AW88399"
+  "CONFIG_SND_HDA_SCODEC_AW88399_I2C"
+  "CONFIG_SND_SOC_AW88399"
+  "CONFIG_SND_SOC_SOF_INTEL_TOPLEVEL"
+  "CONFIG_SND_SOC_SOF_INTEL_COMMON"
+  "CONFIG_SND_SOC_SOF_INTEL_MTL"
+  "CONFIG_SND_SOC_SOF_INTEL_LNL"
+)
+
+CONFIG_FILE="kernel-x86_64-fedora.config"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "❌ Error: $CONFIG_FILE not found"
+  echo "   Are you in the correct directory?"
+  exit 1
+fi
+
+echo "📋 Analyzing file: $CONFIG_FILE"
+echo ""
+
+# Check each option
+missing_options=()
+present_options=()
+
+for option in "${REQUIRED_OPTIONS[@]}"; do
+  if grep -q "^${option}=" "$CONFIG_FILE" 2>/dev/null; then
+    value=$(grep "^${option}=" "$CONFIG_FILE" | cut -d= -f2)
+    echo "✅ $option=$value (already present)"
+    present_options+=("$option")
+  elif grep -q "^# ${option} is not set" "$CONFIG_FILE" 2>/dev/null; then
+    echo "⚠️  $option (disabled, will be enabled)"
+    missing_options+=("$option")
+  else
+    echo "❌ $option (missing, will be added)"
+    missing_options+=("$option")
+  fi
+done
+
+echo ""
+echo "=========================================="
+echo "📊 Summary:"
+echo "   ✅ Options already present: ${#present_options[@]}"
+echo "   ⚠️  Options to add: ${#missing_options[@]}"
+echo "=========================================="
+
+if [ ${#missing_options[@]} -gt 0 ]; then
+  echo ""
+  echo "Options that will be added:"
+  for opt in "${missing_options[@]}"; do
+    echo "   - $opt"
+  done
+fi
+
+echo ""
+EOF
+
+chmod +x check-audio-options.sh
+
+# Run the detection
+./check-audio-options.sh
+```
+
+**Expected result for Fedora 43 kernel 6.18.7:**
+
+```
+📊 Summary:
+   ✅ Options already present: 2
+   ⚠️  Options to add: 5
+
+Options that will be added:
+   - CONFIG_SND_HDA_SCODEC_AW88399
+   - CONFIG_SND_HDA_SCODEC_AW88399_I2C
+   - CONFIG_SND_SOC_SOF_INTEL_COMMON
+   - CONFIG_SND_SOC_SOF_INTEL_MTL
+   - CONFIG_SND_SOC_SOF_INTEL_LNL
+```
+
+---
+
+## 5.3 ▶️ Back up all configuration files
+
+⚠️ **IMPORTANT**: Always back up configuration files before modifying them.
+
+```bash
+cd ~/fedora-kernel-build/kernel
+
+# Create backup directory
+mkdir -p ~/fedora-kernel-build/config-backups
+
+# Copy ALL configuration files
+cp kernel-*.config ~/fedora-kernel-build/config-backups/
+
+# Verify
+echo "✅ Backups created in ~/fedora-kernel-build/config-backups/"
+ls -1 ~/fedora-kernel-build/config-backups/ | wc -l
+echo "files backed up"
+```
+
+**To restore in case of problems:**
+
+```bash
+cp ~/fedora-kernel-build/config-backups/kernel-*.config ~/fedora-kernel-build/kernel/
+```
+
+---
+
+## 5.4 ▶️ Robust script to add audio options
+
+This script:
+
+1. Removes duplicates
+2. Ensures options are added only once
+3. Enables options on x86_64
+4. Disables them on other architectures
+
+```bash
+cd ~/fedora-kernel-build/kernel
+
+# Create the robust addition script
+cat > add-audio-config.sh << 'EOF'
+#!/bin/bash
+
+echo "=========================================="
+echo "  Adding audio options (ROBUST)"
+echo "=========================================="
+echo ""
+
+# Options to add
+OPTIONS_TO_ADD=(
+  "CONFIG_SND_HDA_SCODEC_AW88399"
+  "CONFIG_SND_HDA_SCODEC_AW88399_I2C"
+  "CONFIG_SND_SOC_SOF_INTEL_COMMON"
+  "CONFIG_SND_SOC_SOF_INTEL_MTL"
+  "CONFIG_SND_SOC_SOF_INTEL_LNL"
+)
+
+# Function to clean duplicates in a file
+clean_duplicates() {
+  local config_file="$1"
+  # Use awk to remove duplicates while keeping first occurrence
+  awk '!seen[$0]++' "$config_file" > "${config_file}.tmp"
+  mv "${config_file}.tmp" "$config_file"
+}
+
+# Function to remove all occurrences of an option
+remove_option() {
+  local config_file="$1"
+  local option="$2"
+  sed -i "/^${option}=/d" "$config_file"
+  sed -i "/^# ${option} is not set/d" "$config_file"
+}
+
+# STEP 1: Clean existing duplicates
+echo "=== STEP 1: Cleaning existing duplicates ==="
+for config in kernel-*.config; do
+  clean_duplicates "$config"
+  echo "✅ $config"
+done
+echo ""
+
+# STEP 2: Remove old occurrences of audio options
+echo "=== STEP 2: Removing old occurrences ==="
+for config in kernel-*.config; do
+  for option in "${OPTIONS_TO_ADD[@]}"; do
+    remove_option "$config" "$option"
+  done
+  echo "✅ $config"
+done
+echo ""
+
+# STEP 3: Add options on x86_64 (enabled)
+echo "=== STEP 3: Adding to x86_64 (enabled =m) ==="
+x86_count=0
+for config in kernel-x86_64*-fedora.config kernel-x86_64*-rhel.config; do
+  cat >> "$config" << 'AUDIOCFG'
+
+# Audio fix for Awinic AW88399 (Legion Pro 7i Gen 10)
+CONFIG_SND_HDA_SCODEC_AW88399=m
+CONFIG_SND_HDA_SCODEC_AW88399_I2C=m
+CONFIG_SND_SOC_SOF_INTEL_COMMON=m
+CONFIG_SND_SOC_SOF_INTEL_MTL=m
+CONFIG_SND_SOC_SOF_INTEL_LNL=m
+AUDIOCFG
+  echo "✅ $config"
+  ((x86_count++))
+done
+echo "📊 Total: $x86_count x86_64 files modified"
+echo ""
+
+# STEP 4: Add on other architectures (disabled)
+echo "=== STEP 4: Adding to other architectures (disabled) ==="
+other_count=0
+for config in kernel-*-fedora.config kernel-*-rhel.config; do
+  # Skip x86_64
+  if [[ "$config" == kernel-x86_64* ]]; then
+    continue
+  fi
+
+  cat >> "$config" << 'AUDIOCFG'
+
+# Audio fix for Awinic AW88399 (Legion Pro 7i Gen 10)
+# CONFIG_SND_HDA_SCODEC_AW88399 is not set
+# CONFIG_SND_HDA_SCODEC_AW88399_I2C is not set
+# CONFIG_SND_SOC_SOF_INTEL_COMMON is not set
+# CONFIG_SND_SOC_SOF_INTEL_MTL is not set
+# CONFIG_SND_SOC_SOF_INTEL_LNL is not set
+AUDIOCFG
+  echo "✅ $config"
+  ((other_count++))
+done
+echo "📊 Total: $other_count other architecture files modified"
+echo ""
+
+# STEP 5: Final verification
+echo "=== STEP 5: Anti-duplicate verification ==="
+error_found=0
+
+for config in kernel-*.config; do
+  for option in "${OPTIONS_TO_ADD[@]}"; do
+    # Use grep with word boundary to avoid false positives
+    # (CONFIG_SND_HDA_SCODEC_AW88399_I2C should not match CONFIG_SND_HDA_SCODEC_AW88399)
+    count=$(grep -E -c "^${option}=|^# ${option} is not set" "$config" 2>/dev/null || echo 0)
+    if [ "$count" -gt 1 ]; then
+      echo "❌ ERROR: $config contains $count occurrences of $option (duplicate!)"
+      error_found=1
+    fi
+  done
+done
+
+if [ $error_found -eq 0 ]; then
+  echo "✅ No duplicates detected"
+else
+  echo ""
+  echo "❌ Duplicates were detected!"
+  echo "   Re-run this script to clean up."
+  exit 1
+fi
+
+echo ""
+echo "=========================================="
+echo "✅ Configuration completed successfully!"
+echo "=========================================="
+echo ""
+EOF
+
+chmod +x add-audio-config.sh
+
+# Run the script
+./add-audio-config.sh
+```
+
+**Expected result:**
+
+```
+==========================================
+✅ Configuration completed successfully!
+==========================================
+
+📊 Total: 8 x86_64 files modified
+📊 Total: 31 other architecture files modified
+✅ No duplicates detected
+```
+
+---
+
+## 5.5 ✅ Final verification of added options
+
+```bash
+cd ~/fedora-kernel-build/kernel
+
+echo "=== Verifying x86_64-fedora.config ==="
+grep "CONFIG_SND_HDA_SCODEC_AW88399\|CONFIG_SND_SOC_SOF_INTEL" kernel-x86_64-fedora.config | grep -v SOUNDWIRE | grep -v TOPLEVEL
+
+echo ""
+echo "=== Verifying aarch64-fedora.config ==="
+grep "CONFIG_SND_HDA_SCODEC_AW88399\|CONFIG_SND_SOC_SOF_INTEL" kernel-aarch64-fedora.config | grep -v SOUNDWIRE | grep -v TOPLEVEL
+
+echo ""
+echo "=== Counting occurrences (should be = 2 everywhere) ==="
+echo "x86_64-fedora.config:"
+grep -c "CONFIG_SND_HDA_SCODEC_AW88399" kernel-x86_64-fedora.config
+
+echo "aarch64-fedora.config:"
+grep -c "CONFIG_SND_HDA_SCODEC_AW88399" kernel-aarch64-fedora.config
+```
+
+**Expected result:**
+
+```
+=== Verifying x86_64-fedora.config ===
+CONFIG_SND_HDA_SCODEC_AW88399=m
+CONFIG_SND_HDA_SCODEC_AW88399_I2C=m
+CONFIG_SND_SOC_SOF_INTEL_COMMON=m
+CONFIG_SND_SOC_SOF_INTEL_MTL=m
+CONFIG_SND_SOC_SOF_INTEL_LNL=m
+
+=== Verifying aarch64-fedora.config ===
+# CONFIG_SND_HDA_SCODEC_AW88399 is not set
+# CONFIG_SND_HDA_SCODEC_AW88399_I2C is not set
+# CONFIG_SND_SOC_SOF_INTEL_COMMON is not set
+# CONFIG_SND_SOC_SOF_INTEL_MTL is not set
+# CONFIG_SND_SOC_SOF_INTEL_LNL is not set
+
+=== Counting occurrences (should be = 2 everywhere) ===
+x86_64-fedora.config: 2
+aarch64-fedora.config: 2
+```
+
+---
+
+## 5.6 ✅ Validation test with `fedpkg prep`
+
+Before launching the full compilation, validate the configuration:
+
+```bash
+cd ~/fedora-kernel-build/kernel
+fedpkg --release f43 prep
+```
+
+If successful, no errors such as:
+
+* `Found unset config items`
+* `reassigning to symbol`
+
+will appear.
+
+---
+
+## 5.7 📋 Summary
+
+| Step | Script                   | Purpose                         |
+| ---: | ------------------------ | ------------------------------- |
+|  5.2 | `check-audio-options.sh` | Detects missing/present options |
+|  5.3 | Manual commands          | Configuration backup            |
+|  5.4 | `add-audio-config.sh`    | Robust option insertion         |
+|  5.5 | Manual checks            | Verification                    |
+|  5.6 | `fedpkg prep`            | Final validation                |
+
+**Added options (5 total):**
+
+* `CONFIG_SND_HDA_SCODEC_AW88399`
+* `CONFIG_SND_HDA_SCODEC_AW88399_I2C`
+* `CONFIG_SND_SOC_SOF_INTEL_COMMON`
+* `CONFIG_SND_SOC_SOF_INTEL_MTL`
+* `CONFIG_SND_SOC_SOF_INTEL_LNL`
+
+✅ You are now ready for **Phase 6: Kernel Compilation**.
+
+---
+
+## Phase 6: Kernel Compilation
+
+### 6.1 ▶️ Local compilation with `fedpkg local`
+
+For a local build:
+
+```bash
+cd ~/fedora-kernel-build/kernel
+
+# Start the compilation
+# --release f43 : REQUIRED because we are working on a local branch
+# --without selftests : skip kernel selftests (saves time)
+# --without debug : do not build the separate kernel-debug package (saves time)
+fedpkg --release f43 local -- --without selftests --without debug
+```
+
+#### Why `--release f43`?
+
+* A local branch `build-6.18.x-audio` was created earlier (Phase 2)
+* `fedpkg` cannot infer the Fedora release from a non-standard branch name
+* `--release f43` explicitly tells `fedpkg` to target Fedora 43
+
+---
+
+#### 💡 Difference between `--without debug` and `--without debuginfo`
+
+**`--without debug`** (✅ Recommended):
+
+* Prevents building the **separate `kernel-debug` package**
+* Does **NOT** affect the main kernel
+* Saves both build time and disk space
+* **No functional downside**
+
+**`--without debuginfo`** (⚠️ Use only if disk space is limited):
+
+* Disables `CONFIG_DEBUG_INFO_BTF` in the main kernel
+* Impacts advanced features:
+
+  * Advanced eBPF tools (bpftrace, some BCC tools)
+  * BTF-based kernel tracing
+  * Some advanced systemd features
+* The kernel will **boot and run normally** for standard usage
+
+✅ **Recommendation**: Always use `--without debug`.
+Only add `--without debuginfo` if disk space is critically limited and advanced tracing/eBPF is not required.
+
+⏱️ **Estimated build time**: 1 to 5 hours depending on CPU performance
+
+---
+
+## Phase 7: Installing the Generated RPMs
+
+### 7.1 ▶️ Configure kernel retention (recommended)
+
+Before installing the custom kernel, configure how many kernels Fedora should keep automatically:
+
+```bash
+sudo nano /etc/dnf/dnf.conf
+installonly_limit=5
+```
+
+**Recommended values**:
+
+* `2` → minimal disk usage
+* `3` → Fedora default
+* `5` → **Recommended for patched kernels**
+
+💡 Setting this *before* installation prevents Fedora from removing your custom kernel during future system updates.
+
+---
+
+### 7.2 ✅ Verify generated packages
+
+```bash
+cd ~/fedora-kernel-build/kernel/x86_64
+ls -lh kernel-6.18.7-200.audio.fc43.x86_64.rpm \
+       kernel-core-6.18.7-200.audio.fc43.x86_64.rpm \
+       kernel-modules-6.18.7-200.audio.fc43.x86_64.rpm \
+       kernel-modules-core-6.18.7-200.audio.fc43.x86_64.rpm \
+       kernel-modules-extra-6.18.7-200.audio.fc43.x86_64.rpm \
+       kernel-devel-6.18.7-200.audio.fc43.x86_64.rpm
+```
+
+> **Note**: `kernel-devel` is generated by the build but is **not installed automatically by Fedora**. It is required only for building external kernel modules.
+
+---
+
+### 7.3 ▶️ Install kernel packages (standard installation – recommended)
+
+```bash
+sudo dnf install -y \
+  kernel-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-core-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-modules-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-modules-core-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-modules-extra-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-devel-6.18.7-200.audio.fc43.x86_64.rpm
+```
+
+---
+
+### 7.4 ▶️ Alternative: Minimal installation
+
+```bash
+sudo dnf install -y \
+  kernel-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-core-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-modules-6.18.7-200.audio.fc43.x86_64.rpm \
+  kernel-modules-core-6.18.7-200.audio.fc43.x86_64.rpm
+```
+
+---
+
+### 7.5 ✅ Installation verification
+
+```bash
+rpm -qa | grep "kernel.*6.18.7.*audio"
+ls -la /boot/*6.18.7*audio*
+ls /lib/modules/ | grep audio
+```
+
+---
+
+## Phase 8: Kernel Signing for Secure Boot
+
+> ⚠️ **THIS PHASE IS MANDATORY IF SECURE BOOT IS ENABLED**
+
+---
+
+### 8.1 ✅ Prerequisite: Existing MOK key
+
+You must already have a Machine Owner Key (MOK) created and enrolled.
+
+Verify that the key exists:
+
+```bash
+ls -la /var/lib/shim-signed/mok/MOK.{priv,der,pem}
+```
+
+Verify that the key is enrolled in UEFI:
+
+```bash
+mokutil --list-enrolled | grep -A5 "Subject:"
+```
+
+---
+
+#### If you do not have a MOK key yet
+
+Create and enroll one:
+
+```bash
+# Create directory
+sudo mkdir -p /var/lib/shim-signed/mok
+
+# Generate private key and certificate
+sudo openssl req -new -x509 -newkey rsa:2048 \
+    -keyout /var/lib/shim-signed/mok/MOK.priv \
+    -outform DER -out /var/lib/shim-signed/mok/MOK.der \
+    -days 36500 -subj "/CN=My Kernel Signing Key/" -nodes
+
+# Convert to PEM format (useful for some tools)
+sudo openssl x509 -inform DER \
+    -in /var/lib/shim-signed/mok/MOK.der \
+    -out /var/lib/shim-signed/mok/MOK.pem
+
+# Enroll the key (requires reboot)
+sudo mokutil --import /var/lib/shim-signed/mok/MOK.der
+```
+
+You will be prompted to define a temporary password.
+
+⚠️ **Important**: Reboot and complete the enrollment in **MokManager** during boot.
+
+```bash
+sudo reboot
+```
+
+---
+
+### 8.2 ▶️ Sign the kernel using `pesign` (Fedora-native method)
+
+`pesign` is the standard Fedora / Red Hat signing tool.
+It relies on an NSS (Network Security Services) database to store certificates and private keys.
+
+> **Note**: All commands are executed with `sudo` for simplicity and consistency, even though `pesign` can be configured for non-root usage.
+
+---
+
+#### Step 1: Create a PKCS#12 bundle (private key + certificate)
+
+```bash
+sudo openssl pkcs12 -export \
+    -out /tmp/MOK.p12 \
+    -inkey /var/lib/shim-signed/mok/MOK.priv \
+    -in /var/lib/shim-signed/mok/MOK.pem \
+    -name "MOK Signing Key"
+```
+
+Press **Enter twice** for an empty password, or set one if preferred.
+
+---
+
+#### Step 2: Import the PKCS#12 bundle into pesign’s NSS database
+
+```bash
+# Remove existing entry if present
+sudo certutil -d /etc/pki/pesign -D -n "MOK Signing Key" 2>/dev/null || true
+
+# Import PKCS#12 (includes private key)
+sudo pk12util -d /etc/pki/pesign -i /tmp/MOK.p12
+
+# Remove temporary file
+sudo rm /tmp/MOK.p12
+```
+
+---
+
+#### Step 3: Verify key import
+
+```bash
+# List certificates
+sudo certutil -d /etc/pki/pesign -L
+```
+
+Expected output:
+
+* `MOK Signing Key` with trust flags `u,u,u`
+
+Verify that the **private key** is present:
+
+```bash
+sudo certutil -d /etc/pki/pesign -K
+```
+
+---
+
+#### Step 4: Sign the kernel image
+
+```bash
+# Backup the unsigned kernel
+sudo cp /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64 \
+        /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64.unsigned
+
+# Sign the kernel
+sudo pesign -n /etc/pki/pesign -c "MOK Signing Key" \
+    -i /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64 \
+    -o /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64.signed \
+    -s
+
+# Verify signed file exists
+ls -lh /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64.signed
+```
+
+---
+
+#### Step 5: Replace the kernel and regenerate GRUB
+
+```bash
+sudo mv /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64.signed \
+        /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64
+```
+
+Regenerate GRUB configuration:
+
+```bash
+sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+```
+
+---
+
+> 💡 **Important note about multiple signatures**
+>
+> After signing, the kernel **may contain multiple signatures**:
+>
+> 1. **Red Hat Test Certificate**
+>    – May be added automatically during Fedora builds
+>    – Ignored by UEFI Secure Boot
+>
+> 2. **Your MOK signature**
+>    – The signature actually validated by Secure Boot
+>
+> This is **normal and expected**.
+> UEFI only requires **one trusted signature** to be present.
+
+---
+
+### 8.3 ✅ Verify kernel signature
+
+#### Verify with `sbverify`
+
+```bash
+sudo sbverify --list /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64
+```
+
+Expected output:
+
+```
+signature 1
+  Red Hat Test Certificate (may be present)
+
+signature 2
+  Subject: CN=My Kernel Signing Key
+```
+
+---
+
+#### Verify that the MOK key is enrolled in UEFI
+
+```bash
+mokutil --list-enrolled
+mokutil --list-enrolled | grep -A5 "Subject:"
+```
+
+---
+
+## Phase 9: Bootloader Configuration
+
+### 9.1 ✅ Fedora uses BLS (Boot Loader Specification)
+
+Fedora uses **BLS entries** located in:
+
+```
+/boot/loader/entries/
+```
+
+```bash
+# List existing BLS entries
+ls -la /boot/loader/entries/
+
+# The RPM installation should have created an entry automatically
+ls /boot/loader/entries/*6.18.7*audio*
+```
+
+---
+
+### 9.2 ✅ Verify the generated BLS entry
+
+```bash
+cat /boot/loader/entries/*6.18.7*audio*.conf
+```
+
+Expected content:
+
+```conf
+title Fedora Linux (6.18.7-200.audio.fc43.x86_64) 43 (Workstation Edition)
+version 6.18.7-200.audio.fc43.x86_64
+linux /vmlinuz-6.18.7-200.audio.fc43.x86_64
+initrd /initramfs-6.18.7-200.audio.fc43.x86_64.img
+options root=UUID=xxxxx-xxxxx ro rhgb quiet
+grub_users $grub_users
+grub_arg --unrestricted
+grub_class fedora
+```
+
+> ⚠️ **Do NOT edit this file manually**
+> Fedora manages BLS entries automatically.
+
+---
+
+### 9.3 ✅ Verify audio-related boot parameters (SOF)
+
+> **Important**
+> The following kernel parameter is **commonly present** on Intel SOF platforms,
+> but **must always be verified**:
+
+```
+snd_intel_dspcfg.dsp_driver=3
+```
+
+Check the current kernel entry:
+
+```bash
+sudo grubby --info=/boot/vmlinuz-6.18.7-200.audio.fc43.x86_64
+```
+
+If the parameter is present, **no action is required**.
+
+> ℹ️ If the parameter is missing (rare on modern Intel systems), it must be added
+> using `grubby --update-kernel`.
+> **Do not edit BLS files directly.**
+
+---
+
+### 9.4 ▶️ Set the default kernel (optional)
+
+```bash
+# Check the current default kernel
+sudo grubby --default-kernel
+
+# Set the audio kernel as default
+sudo grubby --set-default=/boot/vmlinuz-6.18.7-200.audio.fc43.x86_64
+
+# Verify the change
+sudo grubby --default-kernel
+```
+
+---
+
+## Phase 10: NVIDIA Modules and Finalization
+
+### 10.0 📚 Understanding how akmods works
+
+> ✅ **Good news: akmods rebuilds automatically**
+>
+> The `akmods.service` detects new kernels at boot and rebuilds NVIDIA modules
+> automatically if required.
+
+This phase is **optional** if you are willing to:
+
+* wait ~2–3 minutes on first boot
+* see a temporary black screen during module compilation
+
+---
+
+### 10.1 ▶️ Option A: Let akmods rebuild at boot (simplest)
+
+```bash
+# Verify akmods is enabled
+systemctl is-enabled akmods.service
+
+# Reboot — akmods will rebuild automatically
+sudo reboot
+```
+
+---
+
+### 10.2 ▶️ Option B: Build NVIDIA modules manually before reboot (recommended)
+
+```bash
+# Force module rebuild for the new kernel
+sudo akmods --force --kernels 6.18.7-200.audio.fc43.x86_64
+```
+
+Wait until the build completes.
+
+```bash
+# Modules must be present and compressed
+ls -la /lib/modules/6.18.7-200.audio.fc43.x86_64/extra/nvidia/
+```
+
+Expected modules:
+
+```
+nvidia.ko.xz
+nvidia-drm.ko.xz
+nvidia-modeset.ko.xz
+nvidia-uvm.ko.xz
+nvidia-peermem.ko.xz
+```
+
+---
+
+### 🔐 Secure Boot and NVIDIA modules
+
+With Secure Boot enabled:
+
+* akmods **automatically signs** the modules
+* **only if**:
+
+  * akmods keys exist in `/var/lib/akmods/keys/`
+  * and those keys are **enrolled in MOK**
+
+```bash
+# Verify akmods keys
+ls -la /var/lib/akmods/keys/
+
+# Check if they are enrolled
+mokutil --list-enrolled | grep akmods
+```
+
+If the keys are not enrolled:
+
+```bash
+sudo mokutil --import /var/lib/akmods/keys/akmods.der
+# Reboot and confirm enrollment in MokManager
+```
+
+If you manually ran `akmods --force`, update module dependencies:
+
+```bash
+sudo depmod -a 6.18.7-200.audio.fc43.x86_64
+```
+
+> ℹ️ This step is automatic when akmods runs at boot.
+
+---
+
+### 10.3 ✅ Final verification before reboot
+
+```bash
+echo "=== Full verification ==="
+
+echo -e "\n1. Signed kernel:"
+sudo pesign -S -i /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64 | grep "common name"
+
+echo -e "\n2. NVIDIA modules present:"
+ls /lib/modules/6.18.7-200.audio.fc43.x86_64/extra/nvidia/
+
+echo -e "\n3. modules.dep correctness:"
+grep "extra/nvidia/nvidia.ko" \
+  /lib/modules/6.18.7-200.audio.fc43.x86_64/modules.dep | head -1
+
+echo -e "\n4. initramfs timestamp:"
+ls -lh /boot/initramfs-6.18.7-200.audio.fc43.x86_64.img
+
+echo -e "\n5. Enrolled MOK keys:"
+mokutil --list-enrolled | grep "CN="
+```
+
+Expected state:
+
+* Kernel signed with your MOK key
+* NVIDIA modules present and compressed (`.ko.xz`)
+* `modules.dep` references `.ko.xz` (not `.ko`)
+* Recent initramfs (generated automatically by RPM install)
+* Your MOK key and akmods key are enrolled
+
+---
+
+## Phase 11: Reboot and Finalization
+
+### 11.1 ▶️ Pre-reboot preparation (UCM2 file deployment)
+
+**Before rebooting**, the UCM2 audio configuration files must be installed:
+
+```bash
+# Backup original UCM2 files
+sudo cp /usr/share/alsa/ucm2/HDA/HiFi-analog.conf \
+    /usr/share/alsa/ucm2/HDA/HiFi-analog.conf.orig
+sudo cp /usr/share/alsa/ucm2/HDA/HiFi-mic.conf \
+    /usr/share/alsa/ucm2/HDA/HiFi-mic.conf.orig
+
+# Deploy custom UCM2 files for AW88399
+sudo cp -f ~/fedora-kernel-build/16iax10h-linux-sound-saga/fix/ucm2/HiFi-analog.conf \
+    /usr/share/alsa/ucm2/HDA/HiFi-analog.conf
+sudo cp -f ~/fedora-kernel-build/16iax10h-linux-sound-saga/fix/ucm2/HiFi-mic.conf \
+    /usr/share/alsa/ucm2/HDA/HiFi-mic.conf
+```
+
+> ℹ️ These files define the ALSA UCM2 routing required for the AW88399 amplifier.
+
+---
+
+### 11.2 ▶️ Reboot into the new kernel
+
+```bash
+# Final check of the default kernel
+sudo grubby --default-kernel
+# Expected: /boot/vmlinuz-6.18.7-200.audio.fc43.x86_64
+
+# Reboot
+sudo reboot
+```
+
+> ⏳ **During reboot**
+> If Secure Boot is enabled and your MOK key has not yet been enrolled,
+> the **MOK Manager** screen will appear. Follow the on-screen instructions
+> to enroll the key.
+
+---
+
+### 11.3 ✅ Post-boot verification
+
+**After reboot**, verify that the system is running correctly:
+
+```bash
+# Confirm the running kernel
+uname -r
+# Expected: 6.18.7-200.audio.fc43.x86_64
+
+# Verify Secure Boot state
+mokutil --sb-state
+# Expected: SecureBoot enabled
+
+# List loaded kernel modules
+lsmod | grep -E "nvidia|snd_hda|snd_sof"
+```
+
+---
+
+### 11.4 ▶️ Post-boot audio configuration (FIRST installation only)
+
+> ⚠️ **This section is REQUIRED ONLY for the FIRST installation**
+> of the AW88399 audio fix.
+
+If you already have a working patched kernel with audio properly configured,
+**skip this section**.
+
+For a first-time installation, initialize the audio stack:
+
+```bash
+# Reload UCM2 configuration
+alsaucm -c hw:0 reset
+alsaucm -c hw:0 reload
+
+# Calibrate volumes (set to 100% to avoid software attenuation)
+amixer sset -c 0 'Master' 100%
+amixer sset -c 0 'Speaker' 100%
+amixer sset -c 0 'Headphone' 100%
+
+# Display ALSA mixer controls
+amixer -c 0 contents | head -50
+```
+
+> ℹ️ Volume calibration is required once to ensure correct gain staging
+> with the AW88399 amplifier.
+
+---
+
+### 11.5 ✅ Audio tests
+
+```bash
+# List detected audio devices
+aplay -l
+# Expected: "HDA Intel PCH" card with device "hw:0,0"
+
+# Confirm SOF (Sound Open Firmware) is active
+cat /sys/module/snd_intel_dspcfg/parameters/dsp_driver
+# Expected: 3 (SOF enabled)
+
+# Verify AW88399 driver loading
+dmesg | grep -i aw88399
+# Expected: driver and firmware loading messages
+
+# Confirm firmware loading
+dmesg | grep -i "aw88399_acf.bin"
+# Expected: "aw88399_acf.bin loaded successfully"
+
+# Audio playback test
+speaker-test -c 2 -t wav
+# You should hear "Front Left" / "Front Right" alternately
+```
+
+---
+
+### 11.6 ✅ NVIDIA tests (if applicable)
+
+```bash
+# Test NVIDIA driver
+nvidia-smi
+# Should display GPU information
+
+# Display NVIDIA driver version
+cat /proc/driver/nvidia/version
+# Expected: installed driver version (e.g. 565.57.01)
+
+# Confirm NVIDIA kernel modules are loaded
+lsmod | grep nvidia
+```
+
+---
+
+### 11.7 ✅ Error log review
+
+Verify that no critical errors occurred:
+
+```bash
+# Display boot-time errors
+journalctl -b -p err
+
+# Search for audio-related errors
+journalctl -b | grep -i -E "snd|alsa|audio|sof|aw88399"
+
+# Search for NVIDIA-related errors
+journalctl -b | grep -i nvidia
+```
+
+> ✅ **If everything is correct**
+> Audio should be functional, Secure Boot should remain enabled,
+> and the system is ready for cleanup or daily use.
+
+---
+
+## Phase 12: Archiving and Cleanup (Optional)
+
+### 12.1 ▶️ Archive essential RPMs
+
+> **⚠️ Important**: Always back up the RPMs **before** cleaning up.
+
+```bash
+# Create archive directory
+mkdir -p ~/fedora-kernel-build/archive
+
+# Copy RPMs (includes kernel-devel in case it is needed later)
+cd ~/fedora-kernel-build/kernel/x86_64
+cp kernel-6.18.7-200.audio.fc43.x86_64.rpm \
+   kernel-core-6.18.7-200.audio.fc43.x86_64.rpm \
+   kernel-modules-6.18.7-200.audio.fc43.x86_64.rpm \
+   kernel-modules-core-6.18.7-200.audio.fc43.x86_64.rpm \
+   kernel-modules-extra-6.18.7-200.audio.fc43.x86_64.rpm \
+   kernel-devel-6.18.7-200.audio.fc43.x86_64.rpm \
+   ~/fedora-kernel-build/archive/
+```
+
+---
+
+### 12.2 ▶️ Compress the archive
+
+```bash
+# Compress the archive
+cd ~/fedora-kernel-build
+tar -czf kernel-6.18.7-200.audio.fc43-rpms.tar.gz archive/
+
+# Verify the archive
+ls -lh kernel-6.18.7-200.audio.fc43-rpms.tar.gz
+tar -tzf kernel-6.18.7-200.audio.fc43-rpms.tar.gz
+```
+
+---
+
+### 12.3 ▶️ Move the archive and clean up
+
+```bash
+# Move the archive to a permanent location (adjust path as needed)
+mkdir -p ~/kernel-archives
+mv kernel-6.18.7-200.audio.fc43-rpms.tar.gz ~/kernel-archives/
+
+# Optional: completely remove the build directory
+rm -rf ~/fedora-kernel-build/
+```
+
+---
+
+### 12.4 ▶️ Restore RPMs from the archive
+
+If you need to reinstall the kernel later:
+
+```bash
+# Extract the archive
+cd ~/Documents/kernel-archives
+tar -xzf kernel-6.18.7-200.audio.fc43-rpms.tar.gz
+cd archive
+
+# Reinstall the packages
+sudo dnf install -y kernel-6.18.7-200.audio.fc43.x86_64.rpm \
+                    kernel-core-6.18.7-200.audio.fc43.x86_64.rpm \
+                    kernel-modules-6.18.7-200.audio.fc43.x86_64.rpm \
+                    kernel-modules-core-6.18.7-200.audio.fc43.x86_64.rpm \
+                    kernel-modules-extra-6.18.7-200.audio.fc43.x86_64.rpm
+```
+
+> ℹ️ `kernel-devel` is usually not required at runtime unless you need to rebuild external modules.
+
+---
+
+### 12.5 ✅ Manage installed kernels
+
+> **💡 Note**: If you followed [Phase 7.1](#71--configure-kernel-retention-recommended), kernel retention is already configured.
+
+**Verify and clean up old kernels**:
+
+```bash
+# Check current install-only configuration
+grep installonly_limit /etc/dnf/dnf.conf
+
+# List installed kernels
+rpm -qa | grep ^kernel-core | sort
+
+# Remove old kernels automatically (optional)
+sudo dnf remove --oldinstallonly --setopt installonly_limit=2 kernel
+
+# Or remove a specific kernel manually
+sudo dnf remove kernel-6.17.x-xxx.fc43.x86_64
+```
+
+> **⚠️ Important**
+> Always keep **at least two kernels** installed so you can boot a known-good
+> kernel if the patched one fails.

--- a/patch-kernel-fedora/README.md
+++ b/patch-kernel-fedora/README.md
@@ -1,0 +1,55 @@
+# Fedora Kernel Patching Guide
+
+This directory contains resources for building the Fedora kernel with the AW88399 audio patch.
+
+## Contents
+
+- **[FEDORA-BUILD-GUIDE.md](FEDORA-BUILD-GUIDE.md)** - Complete step-by-step guide for manually building the patched Fedora kernel with Secure Boot support
+- **[automation/](automation/)** - Automated build scripts
+
+## Quick Start
+
+### Option 1: Automated Build (Recommended)
+
+```bash
+cd automation/scripts
+./build-kernel.sh --help
+./build-kernel.sh
+```
+
+The automation script handles:
+- MOK signing setup for Secure Boot
+- Fetching patches/firmware/UCM2 from upstream
+- Cloning and configuring Fedora kernel sources
+- Building kernel RPMs
+- Installing and signing the kernel
+
+### Option 2: Manual Build
+
+Follow the [FEDORA-BUILD-GUIDE.md](FEDORA-BUILD-GUIDE.md) for detailed step-by-step instructions.
+
+## Why Fedora Kernel?
+
+Building the Fedora kernel (instead of vanilla) provides:
+
+- **Secure Boot compatibility** with MOK keys
+- **Native RPM packages** for clean install/uninstall
+- **akmods integration** for NVIDIA and other proprietary drivers
+- **Fedora patches** and optimizations included
+
+## Requirements
+
+- Fedora 43+ (tested on 6.18.x kernels)
+- ~50GB free disk space for build
+- Basic familiarity with terminal commands
+
+## Configuration
+
+Edit `automation/config/build.conf` to customize:
+- Signing options
+- Build flags
+- Paths and directories
+
+## Supported Devices
+
+See the main [README](../README.md) for the list of compatible devices.

--- a/patch-kernel-fedora/automation/config/build.conf
+++ b/patch-kernel-fedora/automation/config/build.conf
@@ -1,0 +1,100 @@
+# AW88399 Kernel Build Configuration
+# ====================================
+
+# ============================================================================
+# KERNEL SIGNING
+# ============================================================================
+
+# Enable kernel signing for Secure Boot
+# When true, the script will verify MOK setup before building
+ENABLE_SIGNING=true
+
+# MOK (Machine Owner Key) configuration
+# Path to MOK key directory (leave empty for default: /var/lib/shim-signed/mok)
+MOK_KEY_DIR=""
+
+# Certificate name used in pesign NSS database
+MOK_CERT_NAME="MOK Signing Key"
+
+# Common Name for new MOK certificates (if creating new key)
+MOK_KEY_CN="Kernel Signing Key"
+
+# Certificate validity in days (default: ~100 years)
+MOK_VALIDITY_DAYS=36500
+
+# ============================================================================
+# BUILD OPTIONS
+# ============================================================================
+
+# Fedora version (auto-detected by default, can override)
+# Leave empty for automatic detection from current system
+FEDORA_RELEASE=""  # Auto: f43, f44, etc.
+
+# BuildID to identify your custom kernel (appears in uname -r)
+BUILD_ID=".audio"
+
+# Compilation options (all default to true for faster builds)
+BUILD_WITHOUT_SELFTESTS=true   # Skip kernel selftests compilation
+BUILD_WITHOUT_DEBUG=true       # Skip separate kernel-debug package
+BUILD_WITHOUT_DEBUGINFO=false  # Keep BTF info for eBPF (recommended)
+
+# ============================================================================
+# RESOURCE MANAGEMENT
+# ============================================================================
+
+# Upstream repository for patches, firmware, and UCM2 files
+# The script clones this repo to get the latest resources
+AUDIO_FIX_REPO="https://github.com/nadimkobeissi/16iax10h-linux-sound-saga.git"
+
+# ============================================================================
+# VERSION DETECTION
+# ============================================================================
+
+# Number of versions to show per major version (6.18.x, 6.19.x)
+MAX_VERSIONS_PER_MAJOR=5
+
+# ============================================================================
+# PATHS
+# ============================================================================
+
+# Main working directory for kernel build
+WORK_DIR="$HOME/fedora-kernel-build"
+
+# Resource cache directory (for cloned fix repo)
+RESOURCE_CACHE_DIR="${WORK_DIR}/resources"
+
+# ============================================================================
+# LOGGING
+# ============================================================================
+
+# Log directory (relative to script location or absolute path)
+# Leave empty to use default: ./logs in the automation directory
+LOG_DIR=""
+LOG_LEVEL="INFO"  # DEBUG, INFO, WARN, ERROR
+
+# ============================================================================
+# SECURITY
+# ============================================================================
+
+# Auto-install RPMs without confirmation (false = ask for confirmation)
+AUTO_INSTALL=false
+
+# Set new kernel as default boot entry after successful build
+SET_DEFAULT_KERNEL=true
+
+# ============================================================================
+# CLEANUP & ARCHIVING
+# ============================================================================
+
+# Archive RPMs before cleaning up build directories
+ARCHIVE_RPMS=true
+
+# Directory where to store archived RPMs (compressed .tar.gz)
+ARCHIVE_DIR="$HOME/kernel-archives"
+
+# ============================================================================
+# STATE MANAGEMENT (for resume after reboot)
+# ============================================================================
+
+# State file location (for resuming script after MOK enrollment reboot)
+STATE_FILE="/tmp/kernel-build-state"

--- a/patch-kernel-fedora/automation/scripts/build-kernel.sh
+++ b/patch-kernel-fedora/automation/scripts/build-kernel.sh
@@ -1,0 +1,887 @@
+#!/bin/bash
+#
+# Automated Fedora Kernel Build Script with AW88399 Audio Patch
+# ==============================================================
+#
+# This script automates the entire process of:
+# 1. Setting up MOK signing for Secure Boot (with reboot support)
+# 2. Fetching patches/firmware/UCM2 from upstream repository
+# 3. Cloning Fedora kernel repository
+# 4. Selecting desired kernel version
+# 5. Applying AW88399 audio patch
+# 6. Configuring audio kernel options
+# 7. Building kernel RPMs
+# 8. Installing kernel RPMs
+# 9. Signing kernel for Secure Boot
+#
+# Usage:
+#   ./build-kernel.sh [options]
+#
+# Options:
+#   -c, --config FILE      Use custom config file (default: ../config/build.conf)
+#   -v, --version VER      Build specific kernel version (skip interactive selection)
+#   --skip-setup           Skip setup phase (assume environment is ready)
+#   --skip-cleanup         Skip cleanup phase after build
+#   --cleanup-only         Only run cleanup (archive and remove build dirs)
+#   --install-firmware     Only install firmware and UCM2 files
+#   --post-install         Run post-install audio configuration
+#   --setup-mok            Only setup MOK signing (create keys, enroll, configure pesign)
+#   --check                Quick check of system status (no modifications)
+#   --no-sign              Build without signing (ignore ENABLE_SIGNING setting)
+#   -h, --help             Show this help message
+#
+
+set -euo pipefail
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Default config file
+CONFIG_FILE="${PROJECT_ROOT}/config/build.conf"
+
+# Control flags
+SKIP_SETUP=false
+SKIP_CLEANUP=false
+CLEANUP_ONLY=false
+INSTALL_FIRMWARE_ONLY=false
+POST_INSTALL_ONLY=false
+SETUP_MOK_ONLY=false
+CHECK_ONLY=false
+NO_SIGN=false
+
+# Cleanup handler for unexpected exits
+cleanup_on_exit() {
+    local exit_code=$?
+    if ((exit_code != 0 && exit_code != 130)); then
+        echo ""
+        echo "[ERROR] Script failed with exit code: $exit_code" >&2
+        if [[ -n "${LOG_FILE:-}" ]]; then
+            echo "[ERROR] Check log file: $LOG_FILE" >&2
+        fi
+        if [[ -n "${WORK_DIR:-}" && -d "$WORK_DIR" ]]; then
+            echo "[INFO] Partial build may remain at: $WORK_DIR" >&2
+        fi
+    fi
+}
+trap cleanup_on_exit EXIT
+
+# Handle Ctrl+C gracefully
+trap 'echo ""; echo "Interrupted by user. Exiting..."; exit 130' INT TERM
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -c|--config)
+            if [[ -z "${2:-}" ]]; then
+                echo "ERROR: --config requires a file path" >&2
+                exit 1
+            fi
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        -v|--version)
+            if [[ -z "${2:-}" ]]; then
+                echo "ERROR: --version requires a version string" >&2
+                exit 1
+            fi
+            KERNEL_VERSION="$2"
+            shift 2
+            ;;
+        --skip-setup)
+            SKIP_SETUP=true
+            shift
+            ;;
+        --skip-cleanup)
+            SKIP_CLEANUP=true
+            shift
+            ;;
+        --cleanup-only)
+            CLEANUP_ONLY=true
+            shift
+            ;;
+        --install-firmware)
+            INSTALL_FIRMWARE_ONLY=true
+            shift
+            ;;
+        --post-install)
+            POST_INSTALL_ONLY=true
+            shift
+            ;;
+        --setup-mok)
+            SETUP_MOK_ONLY=true
+            shift
+            ;;
+        --check)
+            CHECK_ONLY=true
+            shift
+            ;;
+        --no-sign)
+            NO_SIGN=true
+            shift
+            ;;
+        -h|--help)
+            grep "^#" "$0" | grep -v "^#!/" | sed 's/^# //' | sed 's/^#//'
+            exit 0
+            ;;
+        *)
+            echo "ERROR: Unknown option: $1" >&2
+            echo "Use --help for usage information" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Load configuration
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "ERROR: Config file not found: $CONFIG_FILE" >&2
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+
+# Override signing if --no-sign specified
+if [[ "$NO_SIGN" == true ]]; then
+    ENABLE_SIGNING=false
+fi
+
+# Load library functions (order matters - logging first)
+# shellcheck source=lib/logging.sh
+source "${SCRIPT_DIR}/lib/logging.sh"
+# shellcheck source=lib/config-validator.sh
+source "${SCRIPT_DIR}/lib/config-validator.sh"
+# shellcheck source=lib/version-detection.sh
+source "${SCRIPT_DIR}/lib/version-detection.sh"
+# shellcheck source=lib/patch-manager.sh
+source "${SCRIPT_DIR}/lib/patch-manager.sh"
+# shellcheck source=lib/mok-manager.sh
+source "${SCRIPT_DIR}/lib/mok-manager.sh"
+# shellcheck source=lib/signing.sh
+source "${SCRIPT_DIR}/lib/signing.sh"
+# shellcheck source=lib/resources.sh
+source "${SCRIPT_DIR}/lib/resources.sh"
+# shellcheck source=lib/setup.sh
+source "${SCRIPT_DIR}/lib/setup.sh"
+# shellcheck source=lib/cleanup.sh
+source "${SCRIPT_DIR}/lib/cleanup.sh"
+
+# Validate and apply configuration defaults
+validate_and_prepare_config || {
+    echo "ERROR: Configuration validation failed" >&2
+    exit 1
+}
+
+# Initialize logging
+init_logging "$LOG_DIR"
+
+log_section "Automated Kernel Build - AW88399 Audio Patch"
+log_info "Configuration: $CONFIG_FILE"
+log_info "Work directory: $WORK_DIR"
+
+# ============================================================================
+# MODE: Quick Check
+# ============================================================================
+
+if [[ "$CHECK_ONLY" == true ]]; then
+    quick_setup_check
+    exit 0
+fi
+
+# ============================================================================
+# MODE: MOK Setup Only
+# ============================================================================
+
+if [[ "$SETUP_MOK_ONLY" == true ]]; then
+    interactive_signing_setup
+    exit $?
+fi
+
+# ============================================================================
+# MODE: Post-Install Audio Configuration
+# ============================================================================
+
+if [[ "$POST_INSTALL_ONLY" == true ]]; then
+    log_section "Post-Install Audio Configuration"
+
+    log_info "This configures audio after first boot with the patched kernel"
+    echo ""
+
+    # Check if we're running on patched kernel
+    CURRENT_KERNEL=$(uname -r)
+    if [[ "$CURRENT_KERNEL" == *"audio"* ]]; then
+        log_success "Running on patched kernel: $CURRENT_KERNEL"
+    else
+        log_warn "Not running on patched kernel: $CURRENT_KERNEL"
+        log_info "Make sure to boot into the patched kernel first"
+    fi
+
+    # Reload UCM2 configuration
+    log_step 1 "Reloading UCM2 configuration"
+    if command -v alsaucm &>/dev/null; then
+        alsaucm -c hw:0 reset 2>/dev/null || true
+        alsaucm -c hw:0 reload 2>/dev/null || true
+        log_success "UCM2 configuration reloaded"
+    else
+        log_warn "alsaucm not found"
+    fi
+
+    # Set volume levels
+    log_step 2 "Setting volume levels (100% for optimal quality)"
+    if command -v amixer &>/dev/null; then
+        amixer sset -c 0 'Master' 100% 2>/dev/null || true
+        amixer sset -c 0 'Speaker' 100% 2>/dev/null || true
+        amixer sset -c 0 'Headphone' 100% 2>/dev/null || true
+        log_success "Volume levels configured"
+    else
+        log_warn "amixer not found"
+    fi
+
+    # Show ALSA controls
+    log_step 3 "Current ALSA controls"
+    if command -v amixer &>/dev/null; then
+        echo ""
+        amixer -c 0 contents 2>/dev/null | head -30 || true
+        echo ""
+    fi
+
+    # Verify audio devices
+    log_step 4 "Verifying audio devices"
+    if command -v aplay &>/dev/null; then
+        echo ""
+        aplay -l 2>/dev/null || true
+        echo ""
+    fi
+
+    # Check driver status
+    log_step 5 "Checking AW88399 driver status"
+    echo ""
+    dmesg | grep -i aw88399 | tail -10 || log_info "No AW88399 messages in dmesg"
+    echo ""
+
+    # Check firmware
+    log_step 6 "Checking firmware status"
+    dmesg | grep -i "aw88399_acf.bin" | tail -5 || log_info "No firmware messages in dmesg"
+    echo ""
+
+    echo "=============================================="
+    echo "  Post-Install Configuration Complete!"
+    echo "=============================================="
+    echo ""
+    echo "Test audio with:"
+    echo "  speaker-test -c 2 -t wav"
+    echo ""
+    echo "If audio doesn't work, try:"
+    echo "  systemctl --user restart pipewire pipewire-pulse wireplumber"
+    echo "=============================================="
+    echo ""
+
+    exit 0
+fi
+
+# ============================================================================
+# MODE: Firmware Installation Only
+# ============================================================================
+
+if [[ "$INSTALL_FIRMWARE_ONLY" == true ]]; then
+    log_section "Firmware Installation Mode"
+    log_info "Installing firmware and UCM2 files"
+
+    # Fetch resources from upstream
+    if ! fetch_all_resources; then
+        log_error "Failed to fetch resources from upstream"
+        exit 1
+    fi
+
+    # Install firmware
+    if ! install_firmware; then
+        log_error "Failed to install firmware"
+        exit 1
+    fi
+
+    # Install UCM2
+    if ! install_ucm2; then
+        log_warn "Failed to install UCM2 (may need manual setup)"
+    fi
+
+    # Reload ALSA
+    log_step 3 "Reloading ALSA configuration"
+    if command -v alsaucm &>/dev/null; then
+        alsaucm -c hw:0 reset 2>/dev/null || true
+        alsaucm -c hw:0 reload 2>/dev/null || true
+        log_success "ALSA configuration reloaded"
+    else
+        log_info "alsaucm not found, skip ALSA reload"
+    fi
+
+    echo ""
+    echo "=============================================="
+    echo "  Firmware Installation Complete!"
+    echo "=============================================="
+    echo ""
+    echo "Next steps:"
+    echo "  1. Restart audio services:"
+    echo "     systemctl --user restart pipewire pipewire-pulse wireplumber"
+    echo ""
+    echo "  2. Or reboot for changes to take full effect"
+    echo "=============================================="
+    echo ""
+
+    exit 0
+fi
+
+# ============================================================================
+# MODE: Cleanup Only
+# ============================================================================
+
+if [[ "$CLEANUP_ONLY" == true ]]; then
+    log_info "Cleanup-only mode: Archiving RPMs and removing build directories"
+
+    if [[ -d "${WORK_DIR}/kernel/x86_64" ]]; then
+        BUILT_KERNEL_VERSION=$(ls "${WORK_DIR}/kernel/x86_64/kernel-[0-9]"*.rpm 2>/dev/null \
+            | head -1 \
+            | grep -oP 'kernel-\K[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[^.]+\.fc[0-9]+\.x86_64' || echo "")
+
+        if [[ -n "$BUILT_KERNEL_VERSION" ]]; then
+            log_info "Detected built kernel: $BUILT_KERNEL_VERSION"
+            run_cleanup "$BUILT_KERNEL_VERSION"
+            log_success "Cleanup completed!"
+            exit 0
+        else
+            log_error "No kernel RPMs found in ${WORK_DIR}/kernel/x86_64"
+            exit 1
+        fi
+    else
+        log_error "Build directory not found: ${WORK_DIR}/kernel/x86_64"
+        log_info "Nothing to clean up"
+        exit 0
+    fi
+fi
+
+# ============================================================================
+# PHASE 0: Setup and Environment Preparation
+# ============================================================================
+
+if [[ "$SKIP_SETUP" == false ]]; then
+    run_setup || error_exit "Setup phase failed"
+else
+    log_info "Skipping setup phase (--skip-setup specified)"
+fi
+
+# ============================================================================
+# PHASE 1: Pre-requisites and Detection
+# ============================================================================
+
+log_section "Phase 1: Pre-requisites"
+
+# Detect Fedora version
+if [[ -z "${FEDORA_RELEASE:-}" ]]; then
+    FEDORA_RELEASE=$(detect_fedora_release) || error_exit "Failed to detect Fedora release"
+    log_info "Auto-detected Fedora release: $FEDORA_RELEASE"
+else
+    log_info "Using configured Fedora release: $FEDORA_RELEASE"
+fi
+
+# Extract numeric Fedora version
+FEDORA_VERSION=$(echo "$FEDORA_RELEASE" | grep -oP '\d+')
+
+# Check required tools
+log_step "1.1" "Checking required tools"
+if ! check_required_tools; then
+    error_exit "Missing required tools"
+fi
+log_success "All required tools present"
+
+# ============================================================================
+# PHASE 2: Kernel Source Preparation
+# ============================================================================
+
+log_section "Phase 2: Kernel Source Preparation"
+
+mkdir -p "$WORK_DIR"
+KERNEL_DIR="${WORK_DIR}/kernel"
+
+log_step "2.1" "Setting up Fedora kernel repository"
+
+if [[ -d "$KERNEL_DIR" ]]; then
+    log_info "Kernel directory exists, updating..."
+    cd "$KERNEL_DIR"
+    git fetch --all || log_warn "Failed to fetch updates"
+else
+    log_info "Cloning Fedora kernel repository (this may take a while)..."
+    cd "$WORK_DIR"
+    fedpkg clone -a kernel || error_exit "Failed to clone kernel repository"
+    cd kernel
+fi
+
+log_success "Kernel repository ready: $KERNEL_DIR"
+
+# Checkout Fedora branch
+log_step "2.2" "Checking out Fedora ${FEDORA_RELEASE} branch"
+git checkout "$FEDORA_RELEASE" || error_exit "Failed to checkout branch $FEDORA_RELEASE"
+log_success "Branch $FEDORA_RELEASE checked out"
+
+# ============================================================================
+# PHASE 3: Version Selection
+# ============================================================================
+
+log_section "Phase 3: Kernel Version Selection"
+
+if [[ -n "${KERNEL_VERSION:-}" ]]; then
+    log_info "Using specified version: $KERNEL_VERSION"
+    SELECTED_VERSION="$KERNEL_VERSION"
+else
+    log_step "3.1" "Detecting available kernel versions"
+    AVAILABLE_VERSIONS=$(list_available_kernel_versions "$KERNEL_DIR" "$MAX_VERSIONS_PER_MAJOR")
+
+    if [[ -z "$AVAILABLE_VERSIONS" ]]; then
+        error_exit "No kernel versions found"
+    fi
+
+    VERSION_COUNT=$(echo "$AVAILABLE_VERSIONS" | wc -l)
+    log_success "Found $VERSION_COUNT versions"
+
+    # Interactive selection
+    SELECTED_VERSION=$(select_kernel_version "$AVAILABLE_VERSIONS" 20)
+    if [[ -z "$SELECTED_VERSION" ]]; then
+        error_exit "No version selected"
+    fi
+fi
+
+log_success "Selected version: kernel-$SELECTED_VERSION"
+
+# Get the right patch for this version
+log_step "3.2" "Selecting patch for kernel $SELECTED_VERSION"
+
+# Extract major.minor for patch selection
+KERNEL_MAJOR_MINOR=$(echo "$SELECTED_VERSION" | grep -oP '^\d+\.\d+')
+
+AUDIO_PATCH=$(get_patch_file "$KERNEL_MAJOR_MINOR") || error_exit "No patch available for kernel $KERNEL_MAJOR_MINOR"
+log_success "Using patch: $(basename "$AUDIO_PATCH")"
+
+# Find commit for selected version
+log_step "3.3" "Finding commit for kernel-$SELECTED_VERSION"
+COMMIT_HASH=$(find_commit_for_version "$KERNEL_DIR" "$SELECTED_VERSION")
+log_success "Commit found: $COMMIT_HASH"
+
+# Create build branch
+BUILD_BRANCH="build-${SELECTED_VERSION}-audio"
+log_step "3.4" "Creating build branch: $BUILD_BRANCH"
+
+git branch -D "$BUILD_BRANCH" 2>/dev/null || true
+git checkout -b "$BUILD_BRANCH" "$COMMIT_HASH" || error_exit "Failed to create build branch"
+log_success "Build branch created: $BUILD_BRANCH"
+
+# ============================================================================
+# PHASE 4: Download Sources
+# ============================================================================
+
+log_section "Phase 4: Downloading Kernel Sources"
+
+log_step "4.1" "Downloading source archives"
+fedpkg sources || error_exit "Failed to download sources"
+
+if ! ls ./*.tar.xz &>/dev/null; then
+    error_exit "Source tarball not found"
+fi
+log_success "Sources downloaded"
+
+log_step "4.2" "Installing build dependencies"
+log_info "This may require sudo password..."
+
+if sudo dnf builddep -y kernel.spec; then
+    log_success "Build dependencies installed"
+else
+    log_warn "Failed to install some dependencies (may already be installed)"
+fi
+
+# ============================================================================
+# PHASE 5: Apply Audio Patch
+# ============================================================================
+
+log_section "Phase 5: Applying Audio Patch"
+
+copy_patch_to_kernel "$AUDIO_PATCH" "$KERNEL_DIR" || error_exit "Failed to copy patch"
+modify_kernel_spec "${KERNEL_DIR}/kernel.spec" "$AUDIO_PATCH" "$BUILD_ID" || \
+    error_exit "Failed to modify kernel.spec"
+
+# ============================================================================
+# PHASE 6: Configure Audio Options
+# ============================================================================
+
+log_section "Phase 6: Audio Kernel Configuration"
+
+log_step "6.1" "Creating audio configuration scripts"
+
+cat > "${KERNEL_DIR}/check-audio-options.sh" << 'CHECKEOF'
+#!/bin/bash
+REQUIRED_OPTIONS=(
+  "CONFIG_SND_HDA_SCODEC_AW88399"
+  "CONFIG_SND_HDA_SCODEC_AW88399_I2C"
+  "CONFIG_SND_SOC_AW88399"
+  "CONFIG_SND_SOC_SOF_INTEL_TOPLEVEL"
+  "CONFIG_SND_SOC_SOF_INTEL_COMMON"
+  "CONFIG_SND_SOC_SOF_INTEL_MTL"
+  "CONFIG_SND_SOC_SOF_INTEL_LNL"
+)
+CONFIG_FILE="kernel-x86_64-fedora.config"
+for option in "${REQUIRED_OPTIONS[@]}"; do
+  if grep -q "^${option}=" "$CONFIG_FILE" 2>/dev/null; then
+    echo "  $option"
+  else
+    echo "  $option (missing)"
+  fi
+done
+CHECKEOF
+
+chmod +x "${KERNEL_DIR}/check-audio-options.sh"
+
+cat > "${KERNEL_DIR}/add-audio-config.sh" << 'ADDEOF'
+#!/bin/bash
+set -e
+
+OPTIONS_TO_ADD=(
+  "CONFIG_SND_HDA_SCODEC_AW88399"
+  "CONFIG_SND_HDA_SCODEC_AW88399_I2C"
+  "CONFIG_SND_SOC_SOF_INTEL_COMMON"
+  "CONFIG_SND_SOC_SOF_INTEL_MTL"
+  "CONFIG_SND_SOC_SOF_INTEL_LNL"
+)
+
+clean_duplicates() {
+  awk '!seen[$0]++' "$1" > "$1.tmp"
+  mv "$1.tmp" "$1"
+}
+
+remove_option() {
+  sed -i "/^${2}=/d" "$1"
+  sed -i "/^# ${2} is not set/d" "$1"
+}
+
+for config in kernel-*.config; do
+  clean_duplicates "$config"
+  for option in "${OPTIONS_TO_ADD[@]}"; do
+    remove_option "$config" "$option"
+  done
+done
+
+for config in kernel-x86_64*-fedora.config kernel-x86_64*-rhel.config; do
+  [ -f "$config" ] || continue
+  cat >> "$config" << 'AUDIOCFG'
+
+# Audio fix for Awinic AW88399
+CONFIG_SND_HDA_SCODEC_AW88399=m
+CONFIG_SND_HDA_SCODEC_AW88399_I2C=m
+CONFIG_SND_SOC_SOF_INTEL_COMMON=m
+CONFIG_SND_SOC_SOF_INTEL_MTL=m
+CONFIG_SND_SOC_SOF_INTEL_LNL=m
+AUDIOCFG
+done
+
+for config in kernel-*-fedora.config kernel-*-rhel.config; do
+  [[ "$config" == kernel-x86_64* ]] && continue
+  [ -f "$config" ] || continue
+  cat >> "$config" << 'AUDIOCFG'
+
+# Audio fix for Awinic AW88399
+# CONFIG_SND_HDA_SCODEC_AW88399 is not set
+# CONFIG_SND_HDA_SCODEC_AW88399_I2C is not set
+# CONFIG_SND_SOC_SOF_INTEL_COMMON is not set
+# CONFIG_SND_SOC_SOF_INTEL_MTL is not set
+# CONFIG_SND_SOC_SOF_INTEL_LNL is not set
+AUDIOCFG
+done
+
+echo "Audio configuration added"
+ADDEOF
+
+chmod +x "${KERNEL_DIR}/add-audio-config.sh"
+
+log_success "Configuration scripts created"
+
+log_step "6.2" "Applying audio configuration"
+cd "$KERNEL_DIR"
+./add-audio-config.sh || error_exit "Failed to add audio configuration"
+
+log_step "6.3" "Verifying audio configuration"
+./check-audio-options.sh
+
+log_step "6.4" "Testing configuration with fedpkg prep"
+rm -rf kernel-*-build/ 2>/dev/null || true
+
+# Helper function to run fedpkg prep with workaround for "fg: no job control" error
+run_fedpkg_prep() {
+    local release="$1"
+    local max_attempts=2
+    local attempt=1
+
+    while ((attempt <= max_attempts)); do
+        log_debug "Attempt $attempt/$max_attempts: running fedpkg prep"
+
+        # Capture output and error
+        local prep_output
+        local prep_exitcode
+
+        if prep_output=$(fedpkg --release "$release" prep 2>&1); then
+            log_debug "fedpkg prep succeeded"
+            return 0
+        else
+            prep_exitcode=$?
+
+            # Check if this is the "fg: no job control" error
+            if echo "$prep_output" | grep -q "fg: no job control"; then
+                log_warn "Detected 'fg: no job control' error (known RPM macro bug)"
+
+                if ((attempt < max_attempts)); then
+                    log_info "Applying workaround: updating python-rpm-macros..."
+
+                    # Try to update the problematic packages
+                    if sudo dnf update -y python3-devel python-rpm-macros rpm-build 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+                        log_success "Packages updated, retrying fedpkg prep..."
+                        ((attempt++))
+                        continue
+                    else
+                        log_warn "Package update failed, but continuing..."
+                    fi
+                fi
+            fi
+
+            # If we get here, either it's not the fg error, or we've exhausted attempts
+            log_error "fedpkg prep failed after $attempt attempt(s)"
+            echo "$prep_output" | tee -a "${LOG_FILE:-/dev/null}"
+            return $prep_exitcode
+        fi
+    done
+
+    return 1
+}
+
+run_fedpkg_prep "$FEDORA_RELEASE" || error_exit "fedpkg prep failed - check configuration"
+log_success "Configuration validated"
+
+# ============================================================================
+# PHASE 7: Build Kernel
+# ============================================================================
+
+log_section "Phase 7: Building Kernel"
+
+log_info "This will take 1-5 hours depending on your machine..."
+log_info "Compilation started at: $(date '+%Y-%m-%d %H:%M:%S')"
+
+# Build fedpkg options array
+build_fedpkg_options() {
+    local opts=()
+    [[ "${BUILD_WITHOUT_SELFTESTS:-true}" == true ]] && opts+=(--without selftests)
+    [[ "${BUILD_WITHOUT_DEBUG:-true}" == true ]] && opts+=(--without debug)
+    [[ "${BUILD_WITHOUT_DEBUGINFO:-false}" == true ]] && opts+=(--without debuginfo)
+    echo "${opts[*]}"
+}
+
+BUILD_OPTIONS=$(build_fedpkg_options)
+log_info "Build options: $BUILD_OPTIONS"
+
+BUILD_START=$(date +%s)
+
+# shellcheck disable=SC2086
+if fedpkg --release "$FEDORA_RELEASE" local $BUILD_OPTIONS; then
+    BUILD_END=$(date +%s)
+    BUILD_DURATION=$((BUILD_END - BUILD_START))
+    BUILD_DURATION_MIN=$((BUILD_DURATION / 60))
+
+    log_success "Kernel build completed in ${BUILD_DURATION_MIN} minutes"
+else
+    error_exit "Kernel build failed"
+fi
+
+log_step "7.1" "Verifying generated RPMs"
+RPM_DIR="${KERNEL_DIR}/x86_64"
+
+if [[ ! -d "$RPM_DIR" ]]; then
+    error_exit "RPM directory not found: $RPM_DIR"
+fi
+
+RPM_COUNT=$(find "$RPM_DIR" -name "*.rpm" -type f 2>/dev/null | wc -l)
+if ((RPM_COUNT == 0)); then
+    error_exit "No RPMs generated"
+fi
+
+log_success "Found $RPM_COUNT RPM packages"
+
+echo ""
+echo "=== Generated RPMs ==="
+ls -lh "$RPM_DIR"/*.rpm | head -20
+echo ""
+
+# ============================================================================
+# PHASE 8: Install Kernel RPMs
+# ============================================================================
+
+log_section "Phase 8: Installing Kernel RPMs"
+
+KERNEL_RPM=$(find "$RPM_DIR" -name "kernel-[0-9]*.rpm" -type f \
+    | grep -v "kernel-core\|kernel-modules\|kernel-devel\|kernel-headers" \
+    | head -n1)
+
+if [[ -z "$KERNEL_RPM" ]]; then
+    error_exit "No kernel RPM found"
+fi
+
+KERNEL_VERSION_FULL=$(basename "$KERNEL_RPM" .rpm | sed 's/^kernel-//')
+
+log_info "Installing kernel version: $KERNEL_VERSION_FULL"
+
+RPMS_TO_INSTALL=(
+    "kernel-${KERNEL_VERSION_FULL}.rpm"
+    "kernel-core-${KERNEL_VERSION_FULL}.rpm"
+    "kernel-modules-${KERNEL_VERSION_FULL}.rpm"
+    "kernel-modules-core-${KERNEL_VERSION_FULL}.rpm"
+    "kernel-modules-extra-${KERNEL_VERSION_FULL}.rpm"
+    "kernel-devel-${KERNEL_VERSION_FULL}.rpm"
+)
+
+log_step "8.1" "Installing kernel RPMs"
+cd "$RPM_DIR"
+
+INSTALL_LIST=()
+for rpm in "${RPMS_TO_INSTALL[@]}"; do
+    if [[ -f "$rpm" ]]; then
+        INSTALL_LIST+=("$rpm")
+        log_debug "Will install: $rpm"
+    fi
+done
+
+if ((${#INSTALL_LIST[@]} == 0)); then
+    error_exit "No RPMs found to install"
+fi
+
+if sudo dnf install -y "${INSTALL_LIST[@]}"; then
+    log_success "Kernel RPMs installed successfully"
+else
+    error_exit "Failed to install kernel RPMs"
+fi
+
+log_step "8.2" "Verifying kernel installation"
+
+VMLINUZ_PATH="/boot/vmlinuz-${KERNEL_VERSION_FULL}"
+if [[ -f "$VMLINUZ_PATH" ]]; then
+    log_success "Kernel installed: $VMLINUZ_PATH"
+else
+    error_exit "Kernel not found at $VMLINUZ_PATH after installation"
+fi
+
+MODULES_PATH="/lib/modules/${KERNEL_VERSION_FULL}"
+if [[ -d "$MODULES_PATH" ]]; then
+    log_success "Modules installed: $MODULES_PATH"
+else
+    log_warn "Modules directory not found: $MODULES_PATH"
+fi
+
+# ============================================================================
+# PHASE 9: Install Firmware and UCM2
+# ============================================================================
+
+log_section "Phase 9: Installing Firmware and UCM2"
+
+install_firmware || log_warn "Firmware installation failed"
+install_ucm2 || log_warn "UCM2 installation failed"
+
+# ============================================================================
+# PHASE 10: Kernel Signing
+# ============================================================================
+
+if [[ "${ENABLE_SIGNING:-true}" == true ]]; then
+    log_section "Phase 10: Kernel Signing"
+
+    if check_signing_prerequisites; then
+        log_info "Signing prerequisites verified"
+
+        if [[ -f "$VMLINUZ_PATH" ]]; then
+            sign_kernel_pesign "$VMLINUZ_PATH" "${MOK_CERT_NAME:-MOK Signing Key}" || \
+                log_warn "Kernel signing failed (kernel will boot but Secure Boot may fail)"
+        else
+            log_warn "Kernel not found at $VMLINUZ_PATH, skipping signing"
+        fi
+    else
+        log_warn "Signing prerequisites not met, skipping signing"
+        log_info "Run '$0 --setup-mok' to configure signing"
+    fi
+else
+    log_info "Kernel signing disabled (ENABLE_SIGNING=false or --no-sign)"
+fi
+
+# ============================================================================
+# PHASE 11: Cleanup and Archive
+# ============================================================================
+
+if [[ "$SKIP_CLEANUP" == false ]]; then
+    log_section "Phase 11: Cleanup and Archive"
+
+    BUILT_KERNEL_VERSION="${KERNEL_VERSION_FULL}"
+    if run_cleanup "$BUILT_KERNEL_VERSION"; then
+        log_success "Cleanup completed"
+    else
+        log_warn "Cleanup failed or was cancelled"
+        log_info "Build directories preserved at: $WORK_DIR"
+    fi
+else
+    log_info "Skipping cleanup phase (--skip-cleanup specified)"
+    log_info "Build artifacts preserved at: $WORK_DIR"
+fi
+
+# ============================================================================
+# BUILD COMPLETE
+# ============================================================================
+
+echo ""
+echo -e "${GREEN}==============================================${NC}"
+echo -e "${GREEN}  Kernel Build Successful!${NC}"
+echo -e "${GREEN}==============================================${NC}"
+echo ""
+echo -e "Kernel version: ${GREEN}${KERNEL_VERSION_FULL}${NC}"
+
+# Set as default kernel if configured
+DEFAULT_KERNEL_SET=false
+if [[ "${SET_DEFAULT_KERNEL:-false}" == true ]]; then
+    log_info "Setting new kernel as default..."
+    if sudo grubby --set-default="/boot/vmlinuz-${KERNEL_VERSION_FULL}"; then
+        DEFAULT_KERNEL_SET=true
+    fi
+fi
+
+if [[ "$DEFAULT_KERNEL_SET" == true ]]; then
+    echo -e "Default:        ${GREEN}Yes${NC}"
+else
+    echo -e "Default:        ${YELLOW}No${NC}"
+fi
+
+echo -e "Log file:       ${BLUE}$LOG_FILE${NC}"
+
+if [[ "${ENABLE_SIGNING:-true}" == true ]] && check_signing_prerequisites &>/dev/null; then
+    echo -e "Signing:        ${GREEN}Enabled${NC} (Secure Boot ready)"
+else
+    echo -e "Signing:        ${YELLOW}Disabled${NC} (manual signing may be needed)"
+fi
+
+echo ""
+echo -e "${BLUE}Next steps:${NC}"
+
+if [[ "$DEFAULT_KERNEL_SET" != true ]]; then
+    echo "  Set as default kernel:"
+    echo -e "     ${YELLOW}sudo grubby --set-default=/boot/vmlinuz-${KERNEL_VERSION_FULL}${NC}"
+    echo ""
+fi
+
+echo "  Reboot and select new kernel:"
+echo -e "     ${YELLOW}sudo reboot${NC}"
+echo ""
+echo "  After first boot, run post-install configuration:"
+echo -e "     ${YELLOW}$0 --post-install${NC}"
+echo ""
+echo "  Verify audio:"
+echo -e "     ${YELLOW}dmesg | grep -i aw88399${NC}"
+echo -e "     ${YELLOW}aplay -l${NC}"
+echo ""
+echo -e "${GREEN}==============================================${NC}"
+echo ""
+
+log_info "Build completed successfully at $(date '+%Y-%m-%d %H:%M:%S')"

--- a/patch-kernel-fedora/automation/scripts/lib/cleanup.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/cleanup.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# Cleanup Library for Kernel Build Artifacts
+# Handles archiving and removal of build directories
+
+# ============================================================================
+# RPM Archiving
+# ============================================================================
+
+# Archive kernel RPMs to compressed archive
+archive_kernel_rpms() {
+    local kernel_version="$1"
+
+    if [[ -z "$kernel_version" ]]; then
+        log_error "Kernel version not specified for archiving"
+        return 1
+    fi
+
+    log_section "Archiving Kernel RPMs"
+
+    local rpm_dir="${WORK_DIR}/kernel/x86_64"
+    if [[ ! -d "$rpm_dir" ]]; then
+        log_warn "RPM directory not found: $rpm_dir"
+        log_warn "Nothing to archive"
+        return 1
+    fi
+
+    local archive_name="kernel-${kernel_version}-rpms.tar.gz"
+    local temp_archive_dir="${WORK_DIR}/archive"
+
+    # List of essential RPMs to archive
+    local rpm_patterns=(
+        "kernel-${kernel_version}.rpm"
+        "kernel-core-${kernel_version}.rpm"
+        "kernel-modules-${kernel_version}.rpm"
+        "kernel-modules-core-${kernel_version}.rpm"
+        "kernel-modules-extra-${kernel_version}.rpm"
+        "kernel-devel-${kernel_version}.rpm"
+    )
+
+    # Create temporary archive directory
+    mkdir -p "$temp_archive_dir"
+
+    # Copy essential RPMs
+    log_info "Copying essential RPMs to archive..."
+    local copied_count=0
+    for pattern in "${rpm_patterns[@]}"; do
+        local rpm_file="${rpm_dir}/${pattern}"
+        if [[ -f "$rpm_file" ]]; then
+            cp "$rpm_file" "$temp_archive_dir/"
+            log_info "  + $(basename "$rpm_file")"
+            ((copied_count++))
+        else
+            log_debug "  - Not found: $(basename "$rpm_file")"
+        fi
+    done
+
+    if ((copied_count == 0)); then
+        log_error "No RPMs were copied to archive"
+        rm -rf "$temp_archive_dir"
+        return 1
+    fi
+
+    # Create compressed archive
+    log_info "Creating compressed archive..."
+    mkdir -p "$ARCHIVE_DIR"
+
+    if tar -czf "${ARCHIVE_DIR}/${archive_name}" -C "${WORK_DIR}" archive/ 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_success "Archive created: ${ARCHIVE_DIR}/${archive_name}"
+
+        # Show archive info
+        local archive_size
+        archive_size=$(du -h "${ARCHIVE_DIR}/${archive_name}" | cut -f1)
+        log_info "Archive size: $archive_size"
+        log_info "Archive contains $copied_count RPM files"
+
+        # Remove temporary archive directory
+        rm -rf "$temp_archive_dir"
+
+        return 0
+    else
+        log_error "Failed to create archive"
+        rm -rf "$temp_archive_dir"
+        return 1
+    fi
+}
+
+# ============================================================================
+# Build Directory Cleanup
+# ============================================================================
+
+# Clean up build directories
+cleanup_build_directories() {
+    log_section "Cleaning up Build Directories"
+
+    local dirs_to_clean=(
+        "${WORK_DIR}"
+    )
+
+    log_warn "This will permanently delete build directories!"
+    log_info "Directories to remove:"
+
+    local total_size=0
+    for dir in "${dirs_to_clean[@]}"; do
+        if [[ -d "$dir" ]]; then
+            local dir_size
+            dir_size=$(du -sh "$dir" 2>/dev/null | cut -f1)
+            log_info "  - $dir (size: $dir_size)"
+        fi
+    done
+
+    # Ask for confirmation in interactive mode
+    if [[ -t 0 ]]; then
+        echo ""
+        echo -e "${YELLOW}Do you want to proceed with cleanup? [y/N]${NC}"
+        read -r response
+        if [[ ! "$response" =~ ^[Yy]$ ]]; then
+            log_info "Cleanup cancelled by user"
+            return 0
+        fi
+    fi
+
+    # Remove directories
+    for dir in "${dirs_to_clean[@]}"; do
+        if [[ -d "$dir" ]]; then
+            local dir_size
+            dir_size=$(du -sh "$dir" 2>/dev/null | cut -f1)
+            log_info "Removing: $dir (size: $dir_size)"
+            if rm -rf "$dir" 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+                log_success "Removed: $dir"
+            else
+                log_error "Failed to remove: $dir"
+            fi
+        else
+            log_info "Directory not found, skipping: $dir"
+        fi
+    done
+
+    log_success "Build directories cleaned up"
+
+    return 0
+}
+
+# ============================================================================
+# Complete Cleanup Workflow
+# ============================================================================
+
+# Run complete cleanup workflow
+run_cleanup() {
+    local kernel_version="$1"
+
+    if [[ -z "$kernel_version" ]]; then
+        log_error "Kernel version not specified for cleanup"
+        return 1
+    fi
+
+    # Archive RPMs if enabled
+    if [[ "${ARCHIVE_RPMS:-true}" == true ]]; then
+        if archive_kernel_rpms "$kernel_version"; then
+            log_info ""
+            log_info "RPMs archived successfully"
+            log_info "To restore RPMs later:"
+            log_info "  cd ${ARCHIVE_DIR}"
+            log_info "  tar -xzf kernel-${kernel_version}-rpms.tar.gz"
+            log_info "  cd archive"
+            log_info "  sudo dnf install -y *.rpm"
+            log_info ""
+        else
+            log_warn "Failed to archive RPMs, skipping cleanup for safety"
+            log_warn "Build directories preserved: ${WORK_DIR}"
+            return 1
+        fi
+    else
+        log_info "Skipping RPM archiving (ARCHIVE_RPMS=false in config)"
+        log_warn "Build directories will be removed without archiving RPMs!"
+
+        if [[ -t 0 ]]; then
+            echo ""
+            echo -e "${YELLOW}Are you sure you want to proceed? [y/N]${NC}"
+            read -r response
+            if [[ ! "$response" =~ ^[Yy]$ ]]; then
+                log_info "Cleanup cancelled by user"
+                return 0
+            fi
+        fi
+    fi
+
+    # Clean up directories
+    cleanup_build_directories
+
+    return 0
+}
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+# List archived kernels
+list_archived_kernels() {
+    log_info "Archived kernels in ${ARCHIVE_DIR}:"
+    echo ""
+
+    if [[ ! -d "$ARCHIVE_DIR" ]]; then
+        log_info "Archive directory does not exist"
+        return 0
+    fi
+
+    local archives=("${ARCHIVE_DIR}"/kernel-*-rpms.tar.gz)
+    if [[ ! -e "${archives[0]}" ]]; then
+        log_info "No kernel archives found"
+        return 0
+    fi
+
+    for archive in "${archives[@]}"; do
+        local name
+        local size
+        name=$(basename "$archive")
+        size=$(du -h "$archive" | cut -f1)
+        echo "  $name ($size)"
+    done
+
+    echo ""
+}
+
+# Restore archived kernel RPMs
+restore_archived_kernel() {
+    local archive_name="$1"
+    local dest_dir="${2:-$(pwd)}"
+
+    if [[ -z "$archive_name" ]]; then
+        log_error "Archive name required"
+        list_archived_kernels
+        return 1
+    fi
+
+    local archive_path="${ARCHIVE_DIR}/${archive_name}"
+
+    if [[ ! -f "$archive_path" ]]; then
+        log_error "Archive not found: $archive_path"
+        list_archived_kernels
+        return 1
+    fi
+
+    log_info "Extracting $archive_name to $dest_dir..."
+
+    if tar -xzf "$archive_path" -C "$dest_dir"; then
+        log_success "Archive extracted to ${dest_dir}/archive/"
+        log_info "To install: cd ${dest_dir}/archive && sudo dnf install -y *.rpm"
+        return 0
+    else
+        log_error "Failed to extract archive"
+        return 1
+    fi
+}

--- a/patch-kernel-fedora/automation/scripts/lib/config-validator.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/config-validator.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Configuration Validator Library
+# Validates build configuration and applies sensible defaults
+
+# Apply default values for optional configuration settings
+apply_config_defaults() {
+    # Logging defaults
+    : "${LOG_LEVEL:=INFO}"
+    : "${LOG_DIR:=/tmp/kernel-build-logs}"
+
+    # Build defaults
+    : "${BUILD_ID:=.custom}"
+    : "${MAX_VERSIONS_PER_MAJOR:=5}"
+    : "${BUILD_WITHOUT_SELFTESTS:=true}"
+    : "${BUILD_WITHOUT_DEBUG:=true}"
+    : "${BUILD_WITHOUT_DEBUGINFO:=false}"
+
+    # Path defaults
+    : "${WORK_DIR:=$HOME/fedora-kernel-build}"
+    : "${RESOURCE_CACHE_DIR:=${WORK_DIR}/resources}"
+
+    # Signing defaults
+    : "${ENABLE_SIGNING:=true}"
+    : "${MOK_CERT_NAME:=MOK Signing Key}"
+    : "${MOK_KEY_CN:=Kernel Signing Key}"
+    : "${MOK_VALIDITY_DAYS:=36500}"
+
+    # Cleanup defaults
+    : "${ARCHIVE_RPMS:=true}"
+    : "${ARCHIVE_DIR:=${WORK_DIR}/archives}"
+
+    # State management
+    : "${STATE_FILE:=/tmp/kernel-build-state}"
+
+    # Security
+    : "${AUTO_INSTALL:=false}"
+
+    # Post-build actions
+    : "${SET_DEFAULT_KERNEL:=false}"
+}
+
+# Validate required configuration settings
+# Returns: 0 if valid, 1 if errors found
+validate_config() {
+    local errors=0
+
+    # Validate LOG_LEVEL
+    case "$LOG_LEVEL" in
+        DEBUG|INFO|WARN|ERROR) ;;
+        *)
+            log_error "Invalid LOG_LEVEL: '$LOG_LEVEL' (must be DEBUG, INFO, WARN, or ERROR)"
+            ((errors++))
+            ;;
+    esac
+
+    # Validate WORK_DIR is set and parent exists
+    if [[ -z "$WORK_DIR" ]]; then
+        log_error "WORK_DIR is not set"
+        ((errors++))
+    else
+        local parent_dir
+        parent_dir=$(dirname "$WORK_DIR")
+        if [[ ! -d "$parent_dir" ]]; then
+            log_error "WORK_DIR parent directory does not exist: $parent_dir"
+            ((errors++))
+        fi
+    fi
+
+    # Validate BUILD_ID format (should start with . or be empty)
+    if [[ -n "$BUILD_ID" && ! "$BUILD_ID" =~ ^\. ]]; then
+        log_warn "BUILD_ID should start with '.' (e.g., '.audio'). Current: '$BUILD_ID'"
+    fi
+
+    # Validate MAX_VERSIONS_PER_MAJOR is a positive integer
+    if [[ ! "$MAX_VERSIONS_PER_MAJOR" =~ ^[0-9]+$ ]] || ((MAX_VERSIONS_PER_MAJOR < 1)); then
+        log_error "MAX_VERSIONS_PER_MAJOR must be a positive integer: '$MAX_VERSIONS_PER_MAJOR'"
+        ((errors++))
+    fi
+
+    # Validate MOK_VALIDITY_DAYS is a positive integer
+    if [[ ! "$MOK_VALIDITY_DAYS" =~ ^[0-9]+$ ]] || ((MOK_VALIDITY_DAYS < 1)); then
+        log_error "MOK_VALIDITY_DAYS must be a positive integer: '$MOK_VALIDITY_DAYS'"
+        ((errors++))
+    fi
+
+    # Validate boolean settings
+    local bool_vars=(
+        "ENABLE_SIGNING"
+        "BUILD_WITHOUT_SELFTESTS"
+        "BUILD_WITHOUT_DEBUG"
+        "BUILD_WITHOUT_DEBUGINFO"
+        "ARCHIVE_RPMS"
+        "AUTO_INSTALL"
+        "SET_DEFAULT_KERNEL"
+    )
+
+    for var in "${bool_vars[@]}"; do
+        local value="${!var}"
+        if [[ "$value" != "true" && "$value" != "false" ]]; then
+            log_error "$var must be 'true' or 'false': '$value'"
+            ((errors++))
+        fi
+    done
+
+    # Validate ARCHIVE_DIR if archiving is enabled
+    if [[ "$ARCHIVE_RPMS" == "true" && -n "$ARCHIVE_DIR" ]]; then
+        local archive_parent
+        archive_parent=$(dirname "$ARCHIVE_DIR")
+        if [[ ! -d "$archive_parent" && ! -w "$(dirname "$archive_parent")" ]]; then
+            log_warn "ARCHIVE_DIR parent may not be writable: $archive_parent"
+        fi
+    fi
+
+    # Validate AUDIO_FIX_REPO URL format
+    if [[ -n "$AUDIO_FIX_REPO" ]]; then
+        if [[ ! "$AUDIO_FIX_REPO" =~ ^https?:// && ! "$AUDIO_FIX_REPO" =~ ^git@ ]]; then
+            log_error "AUDIO_FIX_REPO must be a valid git URL: '$AUDIO_FIX_REPO'"
+            ((errors++))
+        fi
+    fi
+
+    return $((errors > 0 ? 1 : 0))
+}
+
+# Check if all required external tools are available
+# Returns: 0 if all present, 1 if missing tools
+check_required_tools() {
+    local required_tools=(
+        "git"
+        "fedpkg"
+        "rpmbuild"
+        "dnf"
+    )
+
+    local optional_tools=(
+        "pesign"
+        "mokutil"
+        "sbverify"
+        "certutil"
+    )
+
+    local missing=0
+
+    log_debug "Checking required tools..."
+
+    for tool in "${required_tools[@]}"; do
+        if ! command -v "$tool" &>/dev/null; then
+            log_error "Required tool not found: $tool"
+            ((missing++))
+        else
+            log_debug "Found: $tool"
+        fi
+    done
+
+    if ((missing > 0)); then
+        log_error "Missing $missing required tool(s)"
+        return 1
+    fi
+
+    # Check optional tools (warn only)
+    for tool in "${optional_tools[@]}"; do
+        if ! command -v "$tool" &>/dev/null; then
+            log_debug "Optional tool not found: $tool"
+        fi
+    done
+
+    log_debug "All required tools present"
+    return 0
+}
+
+# Validate and prepare configuration
+# This is the main entry point for config validation
+# Returns: 0 on success, 1 on failure
+validate_and_prepare_config() {
+    log_debug "Applying configuration defaults..."
+    apply_config_defaults
+
+    log_debug "Validating configuration..."
+    if ! validate_config; then
+        log_error "Configuration validation failed"
+        return 1
+    fi
+
+    log_debug "Configuration validated successfully"
+    return 0
+}
+
+# Display current configuration (for debugging)
+show_config() {
+    echo ""
+    echo "=== Current Configuration ==="
+    echo ""
+    echo "Paths:"
+    echo "  WORK_DIR=$WORK_DIR"
+    echo "  LOG_DIR=$LOG_DIR"
+    echo "  ARCHIVE_DIR=$ARCHIVE_DIR"
+    echo "  RESOURCE_CACHE_DIR=$RESOURCE_CACHE_DIR"
+    echo ""
+    echo "Build Options:"
+    echo "  BUILD_ID=$BUILD_ID"
+    echo "  FEDORA_RELEASE=${FEDORA_RELEASE:-auto}"
+    echo "  BUILD_WITHOUT_SELFTESTS=$BUILD_WITHOUT_SELFTESTS"
+    echo "  BUILD_WITHOUT_DEBUG=$BUILD_WITHOUT_DEBUG"
+    echo "  BUILD_WITHOUT_DEBUGINFO=$BUILD_WITHOUT_DEBUGINFO"
+    echo ""
+    echo "Signing:"
+    echo "  ENABLE_SIGNING=$ENABLE_SIGNING"
+    echo "  MOK_KEY_DIR=${MOK_KEY_DIR:-default}"
+    echo "  MOK_CERT_NAME=$MOK_CERT_NAME"
+    echo ""
+    echo "Logging:"
+    echo "  LOG_LEVEL=$LOG_LEVEL"
+    echo ""
+}

--- a/patch-kernel-fedora/automation/scripts/lib/logging.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/logging.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Logging Library for Kernel Build Scripts
+# Provides consistent logging with levels, colors, and file output
+
+# Terminal colors (only if stdout is a terminal)
+if [[ -t 1 ]]; then
+    readonly RED='\033[0;31m'
+    readonly GREEN='\033[0;32m'
+    readonly YELLOW='\033[1;33m'
+    readonly BLUE='\033[0;34m'
+    readonly NC='\033[0m'
+else
+    readonly RED=''
+    readonly GREEN=''
+    readonly YELLOW=''
+    readonly BLUE=''
+    readonly NC=''
+fi
+
+# Log level constants (for comparison)
+declare -A LOG_LEVELS=([DEBUG]=0 [INFO]=1 [WARN]=2 [ERROR]=3)
+
+# Global log configuration
+LOG_LEVEL="${LOG_LEVEL:-INFO}"
+LOG_FILE=""
+
+# Initialize logging system
+# Args: $1 = log directory path
+init_logging() {
+    local log_dir="$1"
+
+    if [[ -z "$log_dir" ]]; then
+        log_dir="/tmp"
+    fi
+
+    mkdir -p "$log_dir" 2>/dev/null || {
+        echo "[WARN] Cannot create log directory: $log_dir, using /tmp" >&2
+        log_dir="/tmp"
+    }
+
+    LOG_FILE="${log_dir}/build-$(date +%Y-%m-%d-%H-%M-%S).log"
+
+    # Create log file with header
+    {
+        echo "=== Kernel Build Log ==="
+        echo "Started: $(date)"
+        echo "User: ${USER:-unknown}"
+        echo "Host: $(hostname)"
+        echo "========================"
+        echo ""
+    } > "$LOG_FILE"
+
+    log_info "Log file initialized: $LOG_FILE"
+}
+
+# Internal: Check if message should be logged based on level
+_should_log() {
+    local level="$1"
+    local current_level="${LOG_LEVELS[$LOG_LEVEL]:-1}"
+    local msg_level="${LOG_LEVELS[$level]:-1}"
+    ((msg_level >= current_level))
+}
+
+# Internal: Write to log file
+_log_to_file() {
+    local level="$1"
+    shift
+    local message="$*"
+    local timestamp
+    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+    if [[ -n "$LOG_FILE" && -w "$LOG_FILE" ]]; then
+        echo "[$timestamp] [$level] $message" >> "$LOG_FILE"
+    fi
+}
+
+# Log debug message
+log_debug() {
+    _should_log "DEBUG" || return 0
+    _log_to_file "DEBUG" "$*"
+    echo -e "${BLUE}[DEBUG]${NC} $*"
+}
+
+# Log info message
+log_info() {
+    _should_log "INFO" || return 0
+    _log_to_file "INFO" "$*"
+    echo -e "${GREEN}[INFO]${NC} $*"
+}
+
+# Log warning message
+log_warn() {
+    _should_log "WARN" || return 0
+    _log_to_file "WARN" "$*"
+    echo -e "${YELLOW}[WARN]${NC} $*" >&2
+}
+
+# Log error message
+log_error() {
+    _log_to_file "ERROR" "$*"
+    echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+# Log success message (always shown)
+log_success() {
+    _log_to_file "SUCCESS" "$*"
+    echo -e "${GREEN}[OK]${NC} $*"
+}
+
+# Log section header
+log_section() {
+    local title="$*"
+    _log_to_file "SECTION" "$title"
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}  $title${NC}"
+    echo -e "${BLUE}========================================${NC}"
+    echo ""
+}
+
+# Log step in a process
+# Args: $1 = step number/id, $2+ = description
+log_step() {
+    local step="$1"
+    shift
+    local description="$*"
+    _log_to_file "STEP" "[$step] $description"
+    echo -e "${GREEN}[Step $step]${NC} $description"
+}
+
+# Exit with error message
+# Args: $1+ = error message
+error_exit() {
+    log_error "$*"
+    if [[ -n "$LOG_FILE" ]]; then
+        log_error "Build failed. Check log: $LOG_FILE"
+    fi
+    exit 1
+}
+
+# Get current log file path
+get_log_file() {
+    echo "$LOG_FILE"
+}

--- a/patch-kernel-fedora/automation/scripts/lib/mok-manager.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/mok-manager.sh
@@ -1,0 +1,589 @@
+#!/bin/bash
+# MOK (Machine Owner Key) Manager for Secure Boot Signing
+# Handles MOK key creation, verification, and pesign database setup
+
+# Default MOK key location
+DEFAULT_MOK_DIR="/var/lib/shim-signed/mok"
+
+# State file for resuming after reboot
+STATE_FILE="${STATE_FILE:-/tmp/kernel-build-state}"
+
+# ============================================================================
+# MOK Key Verification Functions
+# ============================================================================
+
+# Check if system supports EFI/UEFI
+check_efi_support() {
+    # Check for EFI system directory
+    if [[ ! -d /sys/firmware/efi ]]; then
+        log_debug "EFI support check: /sys/firmware/efi not found"
+        return 1
+    fi
+
+    # Check for EFI variables directory
+    if [[ ! -d /sys/firmware/efi/efivars ]] && [[ ! -d /sys/firmware/efi/vars ]]; then
+        log_debug "EFI support check: EFI variables directory not found"
+        return 1
+    fi
+
+    log_debug "EFI support check: system supports EFI/UEFI"
+    return 0
+}
+
+# Check if MOK key files exist on disk
+check_mok_files_exist() {
+    local mok_dir="${MOK_KEY_DIR:-$DEFAULT_MOK_DIR}"
+    local priv_key="${mok_dir}/MOK.priv"
+    local der_cert="${mok_dir}/MOK.der"
+
+    log_debug "Checking MOK files in: $mok_dir"
+
+    if [[ -f "$priv_key" && -f "$der_cert" ]]; then
+        log_debug "MOK key files found: $priv_key, $der_cert"
+        return 0
+    fi
+
+    log_debug "MOK key files not found"
+    return 1
+}
+
+# Check if MOK is enrolled in UEFI
+check_mok_enrolled() {
+    local mok_dir="${MOK_KEY_DIR:-$DEFAULT_MOK_DIR}"
+    local der_cert="${mok_dir}/MOK.der"
+
+    if ! command -v mokutil &>/dev/null; then
+        log_warn "mokutil not installed, cannot verify MOK enrollment"
+        return 1
+    fi
+
+    # If we have a specific certificate, check for it
+    if [[ -f "$der_cert" ]]; then
+        local local_fingerprint
+        local_fingerprint=$(openssl x509 -inform DER -in "$der_cert" -noout -fingerprint -sha1 2>/dev/null \
+            | cut -d= -f2 \
+            | tr '[:upper:]' '[:lower:]')
+
+        log_debug "check_mok_enrolled: der_cert=$der_cert"
+        log_debug "check_mok_enrolled: local_fingerprint=$local_fingerprint"
+
+        if [[ -n "$local_fingerprint" ]]; then
+            local mokutil_output
+            mokutil_output=$(mokutil --list-enrolled 2>/dev/null)
+
+            if echo "$mokutil_output" | grep -qF "$local_fingerprint"; then
+                log_debug "Your MOK certificate is enrolled in UEFI"
+                return 0
+            fi
+            log_debug "Your MOK certificate is not enrolled (but other MOKs may be)"
+            return 1
+        fi
+    fi
+
+    # Fallback: Check if any MOK is enrolled
+    if mokutil --list-enrolled 2>/dev/null | grep -q "Subject:"; then
+        log_debug "MOK keys enrolled in UEFI (cannot verify if it's yours)"
+        return 0
+    fi
+
+    log_debug "No MOK keys enrolled in UEFI"
+    return 1
+}
+
+# Check if specific certificate is enrolled in MOK
+check_cert_enrolled() {
+    local cert_cn="$1"
+
+    if mokutil --list-enrolled 2>/dev/null | grep -qF "CN=$cert_cn"; then
+        log_debug "Certificate '$cert_cn' is enrolled in MOK"
+        return 0
+    fi
+
+    log_debug "Certificate '$cert_cn' not found in enrolled MOKs"
+    return 1
+}
+
+# Check if certificate exists in pesign NSS database
+check_pesign_cert() {
+    local cert_name="$1"
+
+    if ! command -v certutil &>/dev/null; then
+        log_error "certutil not installed"
+        return 1
+    fi
+
+    if sudo certutil -d /etc/pki/pesign -L 2>/dev/null | grep -qF "$cert_name"; then
+        log_debug "Certificate '$cert_name' found in pesign database"
+        return 0
+    fi
+
+    log_debug "Certificate '$cert_name' not found in pesign database"
+    return 1
+}
+
+# Check if private key exists in pesign NSS database
+check_pesign_key() {
+    local cert_name="$1"
+
+    if sudo certutil -d /etc/pki/pesign -K 2>/dev/null | grep -qF "$cert_name"; then
+        log_debug "Private key for '$cert_name' found in pesign database"
+        return 0
+    fi
+
+    log_debug "Private key for '$cert_name' not found in pesign database"
+    return 1
+}
+
+# ============================================================================
+# MOK Key Creation Functions
+# ============================================================================
+
+# Create new MOK key pair
+create_mok_key() {
+    local mok_dir="${MOK_KEY_DIR:-$DEFAULT_MOK_DIR}"
+    local key_cn="${MOK_KEY_CN:-Kernel Signing Key}"
+    local validity_days="${MOK_VALIDITY_DAYS:-36500}"
+    local key_size="${MOK_KEY_SIZE:-2048}"
+
+    log_section "Creating New MOK Key Pair"
+
+    # Create directory
+    log_info "Creating MOK directory: $mok_dir"
+    if ! sudo mkdir -p "$mok_dir"; then
+        log_error "Failed to create MOK directory"
+        return 1
+    fi
+
+    # Generate key pair
+    log_info "Generating RSA ${key_size}-bit key pair..."
+    if ! sudo openssl req -new -x509 -newkey "rsa:${key_size}" \
+        -keyout "${mok_dir}/MOK.priv" \
+        -outform DER -out "${mok_dir}/MOK.der" \
+        -days "$validity_days" \
+        -subj "/CN=${key_cn}/" \
+        -nodes 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_error "Failed to generate MOK key pair"
+        return 1
+    fi
+
+    log_success "Key pair generated"
+
+    # Convert to PEM format
+    log_info "Converting certificate to PEM format..."
+    if ! sudo openssl x509 -inform DER \
+        -in "${mok_dir}/MOK.der" \
+        -out "${mok_dir}/MOK.pem" 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_error "Failed to convert certificate to PEM"
+        return 1
+    fi
+
+    log_success "PEM certificate created"
+
+    # Set secure permissions
+    sudo chmod 600 "${mok_dir}/MOK.priv"
+    sudo chmod 644 "${mok_dir}/MOK.der" "${mok_dir}/MOK.pem"
+
+    log_success "MOK key pair created successfully"
+    log_info "Files created:"
+    log_info "  Private key: ${mok_dir}/MOK.priv"
+    log_info "  DER cert:    ${mok_dir}/MOK.der"
+    log_info "  PEM cert:    ${mok_dir}/MOK.pem"
+
+    return 0
+}
+
+# Enroll MOK in UEFI (requires reboot)
+enroll_mok() {
+    local mok_dir="${MOK_KEY_DIR:-$DEFAULT_MOK_DIR}"
+    local der_cert="${mok_dir}/MOK.der"
+
+    log_section "Enrolling MOK in UEFI"
+
+    if [[ ! -f "$der_cert" ]]; then
+        log_error "MOK certificate not found: $der_cert"
+        return 1
+    fi
+
+    # Check if system supports EFI
+    if ! check_efi_support; then
+        log_error "EFI/UEFI is not supported on this system"
+        log_warn "MOK enrollment requires UEFI firmware"
+        log_warn ""
+        log_warn "This system appears to be running in:"
+        log_warn "  - Legacy BIOS mode, OR"
+        log_warn "  - A VM without UEFI support, OR"
+        log_warn "  - An environment without EFI variable access"
+        log_warn ""
+        log_info "You can continue building the kernel, but it will not be signed for Secure Boot"
+        log_info "The kernel will still work on systems with Secure Boot disabled"
+        return 1
+    fi
+
+    log_info "Importing MOK certificate..."
+    log_warn "You will be prompted to set a one-time password"
+    log_warn "Remember this password - you'll need it after reboot!"
+    echo ""
+
+    if ! sudo mokutil --import "$der_cert"; then
+        log_error "Failed to import MOK certificate"
+        return 1
+    fi
+
+    log_success "MOK certificate queued for enrollment"
+    log_warn ""
+    log_warn "IMPORTANT: You must reboot to complete MOK enrollment!"
+    log_warn ""
+    log_warn "After reboot, the MOK Manager will appear:"
+    log_warn "  1. Select 'Enroll MOK'"
+    log_warn "  2. Select 'Continue'"
+    log_warn "  3. Select 'Yes' to confirm"
+    log_warn "  4. Enter the password you just set"
+    log_warn "  5. Select 'Reboot'"
+    log_warn ""
+
+    return 0
+}
+
+# ============================================================================
+# Pesign Database Setup Functions
+# ============================================================================
+
+# Import MOK key into pesign NSS database
+import_to_pesign() {
+    local mok_dir="${MOK_KEY_DIR:-$DEFAULT_MOK_DIR}"
+    local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+    local priv_key="${mok_dir}/MOK.priv"
+    local pem_cert="${mok_dir}/MOK.pem"
+
+    log_section "Importing MOK to Pesign Database"
+
+    # Verify files exist
+    if [[ ! -f "$priv_key" || ! -f "$pem_cert" ]]; then
+        log_error "MOK key files not found in $mok_dir"
+        return 1
+    fi
+
+    # Create PKCS#12 file with secure temporary file
+    log_info "Creating PKCS#12 bundle..."
+    local p12_file
+    p12_file=$(sudo mktemp --tmpdir MOK-XXXXXX.p12)
+
+    # Ensure cleanup on function exit
+    trap 'sudo shred -u "$p12_file" 2>/dev/null || sudo rm -f "$p12_file"' RETURN
+
+    # Set restrictive permissions immediately
+    sudo chmod 600 "$p12_file"
+
+    if ! sudo openssl pkcs12 -export \
+        -out "$p12_file" \
+        -inkey "$priv_key" \
+        -in "$pem_cert" \
+        -name "$cert_name" \
+        -passout pass: 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_error "Failed to create PKCS#12 file"
+        return 1
+    fi
+
+    log_success "PKCS#12 bundle created"
+
+    # Check and remove existing entry if present
+    if sudo certutil -d /etc/pki/pesign -L 2>/dev/null | grep -qF "$cert_name"; then
+        log_warn "Certificate '$cert_name' already exists in pesign database"
+        log_info "Removing existing entry to replace it..."
+        sudo certutil -d /etc/pki/pesign -D -n "$cert_name" 2>/dev/null || true
+    fi
+
+    # Import into pesign database
+    log_info "Importing into pesign NSS database..."
+    if ! sudo pk12util -d /etc/pki/pesign -i "$p12_file" -W "" 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_error "Failed to import into pesign database"
+        return 1
+    fi
+
+    log_success "MOK imported to pesign database"
+
+    # Verify import
+    log_info "Verifying pesign import..."
+
+    echo ""
+    echo "=== Pesign Certificates ==="
+    sudo certutil -d /etc/pki/pesign -L
+    echo ""
+
+    if check_pesign_cert "$cert_name" && check_pesign_key "$cert_name"; then
+        log_success "Certificate and private key verified in pesign database"
+        return 0
+    else
+        log_error "Verification failed - check pesign database"
+        return 1
+    fi
+}
+
+# ============================================================================
+# State Management
+# ============================================================================
+
+# Save state for resuming after reboot
+save_state() {
+    local state="$1"
+    local kernel_version="${2:-}"
+
+    {
+        echo "STATE=$state"
+        echo "KERNEL_VERSION=$kernel_version"
+        echo "TIMESTAMP=$(date +%s)"
+    } > "$STATE_FILE"
+
+    log_debug "State saved: $state"
+}
+
+# Load saved state (safely, without sourcing)
+load_state() {
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo ""
+        return
+    fi
+
+    local state_value=""
+    while IFS='=' read -r key value; do
+        # Strip whitespace
+        key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+        # Skip empty lines and comments
+        [[ -z "$key" || "$key" =~ ^# ]] && continue
+
+        if [[ "$key" == "STATE" ]]; then
+            state_value="$value"
+            break
+        fi
+    done < "$STATE_FILE"
+
+    echo "$state_value"
+}
+
+# Clear saved state
+clear_state() {
+    rm -f "$STATE_FILE"
+    log_debug "State cleared"
+}
+
+# ============================================================================
+# Full MOK Setup Workflow
+# ============================================================================
+
+# Complete MOK setup workflow with user prompts
+setup_mok_workflow() {
+    local mok_dir="${MOK_KEY_DIR:-$DEFAULT_MOK_DIR}"
+    local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+
+    log_section "MOK Signing Setup Workflow"
+
+    # Step 1: Check if MOK files exist
+    log_step "1" "Checking for existing MOK key files"
+
+    if check_mok_files_exist; then
+        log_success "MOK key files found in $mok_dir"
+    else
+        log_warn "MOK key files not found"
+
+        # Check if user provided custom path
+        if [[ -n "${MOK_KEY_DIR:-}" && "$MOK_KEY_DIR" != "$DEFAULT_MOK_DIR" ]]; then
+            log_error "Custom MOK path specified but files not found: $MOK_KEY_DIR"
+            log_info "Please verify the path or remove the MOK_KEY_DIR setting"
+            return 1
+        fi
+
+        # Ask user what to do
+        echo ""
+        echo -e "${YELLOW}No MOK key found. What would you like to do?${NC}"
+        echo "  1) Create a new MOK key pair"
+        echo "  2) Specify path to existing MOK key"
+        echo "  3) Skip signing (build without signature)"
+        echo ""
+        echo -n "Choice [1-3]: "
+        read -r choice
+
+        case "$choice" in
+            1)
+                create_mok_key || return 1
+                ;;
+            2)
+                echo ""
+                echo -n "Enter path to MOK directory: "
+                read -r custom_path
+
+                if [[ -f "${custom_path}/MOK.priv" && -f "${custom_path}/MOK.der" ]]; then
+                    export MOK_KEY_DIR="$custom_path"
+                    log_success "Using MOK from: $custom_path"
+                    log_info "MOK_KEY_DIR exported for this session"
+                else
+                    log_error "MOK files not found in: $custom_path"
+                    log_info "Expected files: MOK.priv, MOK.der"
+                    return 1
+                fi
+                ;;
+            3)
+                log_info "Skipping kernel signing"
+                ENABLE_SIGNING=false
+                return 0
+                ;;
+            *)
+                log_error "Invalid choice"
+                return 1
+                ;;
+        esac
+    fi
+
+    # Step 2: Check if MOK is enrolled in UEFI
+    log_step "2" "Checking MOK enrollment in UEFI"
+
+    if check_mok_enrolled; then
+        log_success "MOK keys are enrolled in UEFI"
+    else
+        log_warn "MOK not enrolled in UEFI"
+
+        echo ""
+        echo -e "${YELLOW}MOK needs to be enrolled in UEFI. This requires a reboot.${NC}"
+        echo ""
+        echo "Options:"
+        echo "  1) Enroll MOK now (will save state and prompt for reboot)"
+        echo "  2) Continue without signing (can sign later)"
+        echo ""
+        echo -n "Choice [1-2]: "
+        read -r choice
+
+        case "$choice" in
+            1)
+                enroll_mok || return 1
+
+                save_state "MOK_ENROLLED_PENDING_REBOOT"
+
+                echo ""
+                echo -e "${YELLOW}========================================${NC}"
+                echo -e "${YELLOW}  REBOOT REQUIRED${NC}"
+                echo -e "${YELLOW}========================================${NC}"
+                echo ""
+                echo "After reboot, run this script again."
+                echo "It will resume from where it left off."
+                echo ""
+                echo -n "Reboot now? [y/N]: "
+                read -r reboot_choice
+
+                if [[ "$reboot_choice" =~ ^[Yy]$ ]]; then
+                    log_warn "Rebooting in 5 seconds... (Ctrl+C to cancel)"
+                    sleep 5
+                    sudo reboot
+                else
+                    log_info "Please reboot manually when ready"
+                    log_info "Then run: $0"
+                    exit 0
+                fi
+                ;;
+            2)
+                log_info "Continuing without signing"
+                ENABLE_SIGNING=false
+                return 0
+                ;;
+            *)
+                log_error "Invalid choice"
+                return 1
+                ;;
+        esac
+    fi
+
+    # Step 3: Check pesign database
+    log_step "3" "Checking pesign database setup"
+
+    if check_pesign_cert "$cert_name" && check_pesign_key "$cert_name"; then
+        log_success "MOK already configured in pesign database"
+    else
+        log_info "MOK not found in pesign database, importing..."
+        import_to_pesign || return 1
+    fi
+
+    log_section "MOK Setup Complete"
+    log_success "Kernel signing is ready!"
+    log_info "Certificate name: $cert_name"
+
+    # Clear any pending state
+    clear_state
+
+    return 0
+}
+
+# Check if signing prerequisites are met (quick check)
+check_signing_prerequisites() {
+    local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+
+    # Check pesign is installed
+    if ! command -v pesign &>/dev/null; then
+        log_debug "pesign not installed"
+        return 1
+    fi
+
+    # Check certificate and key in pesign database
+    if ! check_pesign_cert "$cert_name"; then
+        log_debug "Certificate not in pesign database"
+        return 1
+    fi
+
+    if ! check_pesign_key "$cert_name"; then
+        log_debug "Private key not in pesign database"
+        return 1
+    fi
+
+    return 0
+}
+
+# Display MOK status summary
+show_mok_status() {
+    local mok_dir="${MOK_KEY_DIR:-$DEFAULT_MOK_DIR}"
+    local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+
+    echo ""
+    echo "=== MOK Status Summary ==="
+    echo ""
+
+    # Key files
+    echo -n "MOK Key Files ($mok_dir): "
+    if check_mok_files_exist; then
+        echo -e "${GREEN}Present${NC}"
+    else
+        echo -e "${RED}Missing${NC}"
+    fi
+
+    # UEFI enrollment
+    echo -n "MOK Enrolled in UEFI: "
+    if check_mok_enrolled; then
+        echo -e "${GREEN}Yes${NC}"
+    else
+        echo -e "${RED}No${NC}"
+    fi
+
+    # Pesign database
+    echo -n "Pesign Certificate: "
+    if check_pesign_cert "$cert_name"; then
+        echo -e "${GREEN}Present${NC}"
+    else
+        echo -e "${RED}Missing${NC}"
+    fi
+
+    echo -n "Pesign Private Key: "
+    if check_pesign_key "$cert_name"; then
+        echo -e "${GREEN}Present${NC}"
+    else
+        echo -e "${RED}Missing${NC}"
+    fi
+
+    # Overall status
+    echo ""
+    echo -n "Signing Ready: "
+    if check_signing_prerequisites; then
+        echo -e "${GREEN}Yes${NC}"
+    else
+        echo -e "${RED}No${NC}"
+    fi
+
+    echo ""
+}

--- a/patch-kernel-fedora/automation/scripts/lib/patch-manager.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/patch-manager.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# Patch Manager Library
+# Handles patch application and kernel.spec modification
+
+# ============================================================================
+# Patch Validation
+# ============================================================================
+
+# Validate patch file exists and has valid format
+validate_patch() {
+    local patch_file="$1"
+
+    log_debug "Validating patch: $patch_file"
+
+    if [[ ! -f "$patch_file" ]]; then
+        log_error "Patch file not found: $patch_file"
+        return 1
+    fi
+
+    # Check file is not empty
+    if [[ ! -s "$patch_file" ]]; then
+        log_error "Patch file is empty: $patch_file"
+        return 1
+    fi
+
+    # Check patch format (should contain diff headers)
+    local diff_count
+    diff_count=$(grep -c "^diff " "$patch_file" 2>/dev/null || echo 0)
+
+    if ((diff_count == 0)); then
+        log_error "Patch contains no valid diffs: $patch_file"
+        return 1
+    fi
+
+    log_debug "Patch valid: $diff_count files modified"
+    return 0
+}
+
+# ============================================================================
+# Patch Installation
+# ============================================================================
+
+# Copy patch to kernel directory
+copy_patch_to_kernel() {
+    local patch_src="$1"
+    local kernel_dir="$2"
+
+    log_step "5.1" "Copying audio patch"
+
+    # Validate source patch
+    if ! validate_patch "$patch_src"; then
+        return 1
+    fi
+
+    # Check destination directory
+    if [[ ! -d "$kernel_dir" ]]; then
+        log_error "Kernel directory not found: $kernel_dir"
+        return 1
+    fi
+
+    # Copy patch
+    local patch_name
+    patch_name=$(basename "$patch_src")
+
+    if ! cp "$patch_src" "${kernel_dir}/${patch_name}"; then
+        log_error "Failed to copy patch to $kernel_dir"
+        return 1
+    fi
+
+    log_success "Patch copied: $patch_name"
+    return 0
+}
+
+# ============================================================================
+# kernel.spec Modification
+# ============================================================================
+
+# Modify kernel.spec to add patch and buildid
+modify_kernel_spec() {
+    local spec_file="$1"
+    local patch_file="$2"
+    local build_id="$3"
+
+    log_step "5.2" "Modifying kernel.spec"
+
+    # Validate inputs
+    if [[ ! -f "$spec_file" ]]; then
+        log_error "kernel.spec not found: $spec_file"
+        return 1
+    fi
+
+    if [[ -z "$patch_file" ]]; then
+        log_error "Patch file path is empty"
+        return 1
+    fi
+
+    local patch_name
+    patch_name=$(basename "$patch_file")
+
+    # Backup original spec
+    if [[ ! -f "${spec_file}.orig" ]]; then
+        cp "$spec_file" "${spec_file}.orig"
+        log_debug "Backup created: ${spec_file}.orig"
+    fi
+
+    # Step 1: Add patch declaration
+    log_info "Adding patch declaration..."
+
+    local patch_line
+    patch_line=$(grep -n "^Patch999999:" "$spec_file" | cut -d: -f1)
+
+    if [[ -z "$patch_line" ]]; then
+        log_error "Patch999999 line not found in kernel.spec"
+        log_info "Expected format: Patch999999: linux-kernel-test.patch"
+        return 1
+    fi
+
+    # Insert patch declaration after Patch999999
+    sed -i "${patch_line}a Patch10000: ${patch_name}" "$spec_file"
+    log_success "Patch declared: Patch10000: $patch_name"
+
+    # Step 2: Add patch application
+    log_info "Adding patch application..."
+
+    local apply_line
+    apply_line=$(grep -n "ApplyOptionalPatch linux-kernel-test.patch" "$spec_file" | cut -d: -f1)
+
+    if [[ -z "$apply_line" ]]; then
+        log_error "ApplyOptionalPatch linux-kernel-test.patch line not found"
+        log_info "Cannot determine where to add patch application"
+        return 1
+    fi
+
+    # Insert patch application after linux-kernel-test.patch
+    sed -i "${apply_line}a ApplyOptionalPatch ${patch_name}" "$spec_file"
+    log_success "Patch application added"
+
+    # Step 3: Modify buildid
+    log_info "Setting buildid to '${build_id}'..."
+
+    # Replace commented buildid with active buildid
+    if grep -q "^# define buildid .local$" "$spec_file"; then
+        sed -i "s/^# define buildid .local$/%define buildid ${build_id}/" "$spec_file"
+    elif grep -q "^#define buildid" "$spec_file"; then
+        sed -i "s/^#define buildid.*$/%define buildid ${build_id}/" "$spec_file"
+    else
+        log_warn "Could not find buildid line, adding at top of spec"
+        sed -i "1i %define buildid ${build_id}" "$spec_file"
+    fi
+
+    # Verify buildid was modified
+    if grep -q "^%define buildid ${build_id}" "$spec_file"; then
+        log_success "BuildID set: ${build_id}"
+    else
+        log_error "Failed to set buildid"
+        return 1
+    fi
+
+    # Step 4: Verification
+    log_info "Verifying modifications..."
+
+    echo ""
+    echo "=== Declared Patches ==="
+    grep "^Patch" "$spec_file" | tail -n 3
+
+    echo ""
+    echo "=== BuildID ==="
+    grep "define buildid" "$spec_file" | grep -v "^#"
+
+    echo ""
+    echo "=== Applied Patches ==="
+    grep "ApplyOptionalPatch" "$spec_file" | grep -v "ApplyOptionalPatch()" | tail -n 3
+
+    echo ""
+
+    log_success "kernel.spec modified successfully"
+    return 0
+}
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+# Restore original kernel.spec from backup
+restore_kernel_spec() {
+    local spec_file="$1"
+    local backup_file="${spec_file}.orig"
+
+    if [[ -f "$backup_file" ]]; then
+        if mv "$backup_file" "$spec_file"; then
+            log_success "kernel.spec restored from backup"
+            return 0
+        else
+            log_error "Failed to restore kernel.spec"
+            return 1
+        fi
+    else
+        log_warn "No backup found for kernel.spec"
+        return 1
+    fi
+}
+
+# Show patch status in kernel.spec
+show_patch_status() {
+    local spec_file="$1"
+
+    if [[ ! -f "$spec_file" ]]; then
+        log_error "kernel.spec not found: $spec_file"
+        return 1
+    fi
+
+    echo ""
+    echo "=== Patch Configuration ==="
+    echo ""
+
+    echo "Declared patches:"
+    grep "^Patch" "$spec_file" | tail -5 | while read -r line; do
+        echo "  $line"
+    done
+
+    echo ""
+    echo "Applied patches:"
+    grep "ApplyOptionalPatch" "$spec_file" | grep -v "ApplyOptionalPatch()" | tail -5 | while read -r line; do
+        echo "  $line"
+    done
+
+    echo ""
+    echo "BuildID:"
+    grep "define buildid" "$spec_file" | grep -v "^#" | while read -r line; do
+        echo "  $line"
+    done
+
+    echo ""
+}

--- a/patch-kernel-fedora/automation/scripts/lib/resources.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/resources.sh
@@ -1,0 +1,423 @@
+#!/bin/bash
+# Resource Manager Library
+# Downloads patches, firmware, and UCM2 files from upstream repository
+
+# Default upstream repository
+DEFAULT_AUDIO_FIX_REPO="https://github.com/nadimkobeissi/16iax10h-linux-sound-saga.git"
+
+# Local cache directory for downloaded resources
+RESOURCE_CACHE_DIR="${RESOURCE_CACHE_DIR:-${WORK_DIR}/resources}"
+
+# ============================================================================
+# Repository Management
+# ============================================================================
+
+# Clone or update the audio fix repository
+clone_audio_fix_repo() {
+    local repo_url="${AUDIO_FIX_REPO:-$DEFAULT_AUDIO_FIX_REPO}"
+    local repo_dir="${RESOURCE_CACHE_DIR}/16iax10h-linux-sound-saga"
+
+    log_section "Fetching Audio Fix Resources"
+
+    # Create cache directory
+    mkdir -p "$RESOURCE_CACHE_DIR"
+
+    if [[ -d "$repo_dir/.git" ]]; then
+        # Repository exists, update it
+        log_info "Updating existing repository..."
+        if ! git -C "$repo_dir" pull --ff-only 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+            log_warn "Pull failed, trying fresh clone..."
+            rm -rf "$repo_dir"
+        else
+            log_success "Repository updated"
+            return 0
+        fi
+    fi
+
+    # Clone fresh
+    log_info "Cloning repository: $repo_url"
+    if ! git clone --depth 1 "$repo_url" "$repo_dir" 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_error "Failed to clone repository"
+        return 1
+    fi
+
+    log_success "Repository cloned successfully"
+
+    # Show commit info
+    local commit_hash
+    local commit_date
+    commit_hash=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null)
+    commit_date=$(git -C "$repo_dir" log -1 --format=%ci 2>/dev/null)
+    log_info "Using commit: $commit_hash ($commit_date)"
+
+    return 0
+}
+
+# ============================================================================
+# Patch Management
+# ============================================================================
+
+# Get the appropriate patch file for kernel version
+get_patch_file() {
+    local kernel_version="$1"
+    local repo_dir="${RESOURCE_CACHE_DIR}/16iax10h-linux-sound-saga"
+    local patches_dir="${repo_dir}/fix/patches"
+
+    if [[ ! -d "$patches_dir" ]]; then
+        log_error "Patches directory not found: $patches_dir"
+        log_info "Run clone_audio_fix_repo first"
+        return 1
+    fi
+
+    # Extract major.minor version (e.g., 6.18 from 6.18.6)
+    local major_minor
+    major_minor=$(echo "$kernel_version" | grep -oP '^\d+\.\d+')
+
+    local patch_file=""
+
+    # Try exact match first (e.g., 16iax10h-audio-linux-6.18.patch)
+    if [[ -f "${patches_dir}/16iax10h-audio-linux-${major_minor}.patch" ]]; then
+        patch_file="${patches_dir}/16iax10h-audio-linux-${major_minor}.patch"
+    # Try with full version
+    elif [[ -f "${patches_dir}/16iax10h-audio-linux-${kernel_version}.patch" ]]; then
+        patch_file="${patches_dir}/16iax10h-audio-linux-${kernel_version}.patch"
+    # Fallback: find any patch for this major version
+    else
+        local major
+        major=$(echo "$kernel_version" | cut -d. -f1)
+        patch_file=$(find "$patches_dir" -name "16iax10h-audio-linux-${major}.*.patch" 2>/dev/null \
+            | sort -V \
+            | tail -1)
+    fi
+
+    if [[ -z "$patch_file" || ! -f "$patch_file" ]]; then
+        log_error "No suitable patch found for kernel $kernel_version"
+        log_info "Available patches:"
+        find "$patches_dir" -name "*.patch" -type f 2>/dev/null | while read -r f; do
+            log_info "  - $(basename "$f")"
+        done
+        return 1
+    fi
+
+    log_debug "Found patch: $patch_file"
+    echo "$patch_file"
+    return 0
+}
+
+# Copy patch to kernel build directory
+install_patch() {
+    local kernel_version="$1"
+    local dest_dir="$2"
+
+    log_info "Installing patch for kernel $kernel_version..."
+
+    local patch_file
+    if ! patch_file=$(get_patch_file "$kernel_version"); then
+        return 1
+    fi
+
+    local patch_name
+    patch_name=$(basename "$patch_file")
+    local dest_path="${dest_dir}/${patch_name}"
+
+    if ! cp "$patch_file" "$dest_path"; then
+        log_error "Failed to copy patch to $dest_path"
+        return 1
+    fi
+
+    log_success "Patch installed: $patch_name"
+    echo "$patch_name"
+    return 0
+}
+
+# ============================================================================
+# Firmware Management
+# ============================================================================
+
+# Get firmware file path
+get_firmware_file() {
+    local repo_dir="${RESOURCE_CACHE_DIR}/16iax10h-linux-sound-saga"
+    local firmware_file="${repo_dir}/fix/firmware/aw88399_acf.bin"
+
+    if [[ ! -f "$firmware_file" ]]; then
+        log_error "Firmware file not found: $firmware_file"
+        return 1
+    fi
+
+    echo "$firmware_file"
+    return 0
+}
+
+# Install firmware to system
+install_firmware() {
+    local firmware_dest="/lib/firmware/aw88399_acf.bin"
+
+    log_info "Installing AW88399 firmware..."
+
+    # Get source file
+    local firmware_file
+    if ! firmware_file=$(get_firmware_file); then
+        return 1
+    fi
+
+    # Check if already installed with same content
+    if [[ -f "$firmware_dest" ]]; then
+        local source_md5
+        local dest_md5
+        source_md5=$(md5sum "$firmware_file" | cut -d' ' -f1)
+        dest_md5=$(md5sum "$firmware_dest" | cut -d' ' -f1)
+
+        if [[ "$source_md5" == "$dest_md5" ]]; then
+            log_success "Firmware already installed and up to date"
+            return 0
+        fi
+        log_info "Firmware differs, updating..."
+    fi
+
+    # Copy to system
+    if ! sudo cp "$firmware_file" "$firmware_dest"; then
+        log_error "Failed to copy firmware to $firmware_dest"
+        return 1
+    fi
+
+    # Set permissions
+    sudo chmod 644 "$firmware_dest"
+
+    log_success "Firmware installed: $firmware_dest"
+    return 0
+}
+
+# ============================================================================
+# UCM2 Configuration Management
+# ============================================================================
+
+# Get UCM2 files directory
+get_ucm2_dir() {
+    local repo_dir="${RESOURCE_CACHE_DIR}/16iax10h-linux-sound-saga"
+    local ucm2_dir="${repo_dir}/fix/ucm2"
+
+    if [[ ! -d "$ucm2_dir" ]]; then
+        log_error "UCM2 directory not found: $ucm2_dir"
+        return 1
+    fi
+
+    echo "$ucm2_dir"
+    return 0
+}
+
+# Install UCM2 configuration files
+install_ucm2() {
+    local ucm2_dest="/usr/share/alsa/ucm2/HDA"
+
+    log_info "Installing UCM2 configuration files..."
+
+    # Get source directory
+    local ucm2_source
+    if ! ucm2_source=$(get_ucm2_dir); then
+        return 1
+    fi
+
+    # Verify destination exists
+    if [[ ! -d "$ucm2_dest" ]]; then
+        log_error "UCM2 destination directory not found: $ucm2_dest"
+        log_info "Is alsa-ucm installed?"
+        return 1
+    fi
+
+    # Files to install
+    local ucm2_files=(
+        "HiFi-analog.conf"
+        "HiFi-mic.conf"
+    )
+
+    local installed_count=0
+
+    for file in "${ucm2_files[@]}"; do
+        local source_file="${ucm2_source}/${file}"
+        local dest_file="${ucm2_dest}/${file}"
+        local backup_file="${dest_file}.orig"
+
+        if [[ ! -f "$source_file" ]]; then
+            log_warn "UCM2 source file not found: $source_file"
+            continue
+        fi
+
+        # Create backup if original exists and no backup yet
+        if [[ -f "$dest_file" && ! -f "$backup_file" ]]; then
+            log_info "Backing up original: $file"
+            sudo cp "$dest_file" "$backup_file" || true
+        fi
+
+        # Copy new file
+        if ! sudo cp -f "$source_file" "$dest_file"; then
+            log_error "Failed to copy $file to $ucm2_dest"
+            continue
+        fi
+
+        log_success "Installed: $file"
+        ((installed_count++))
+    done
+
+    if ((installed_count == 0)); then
+        log_error "No UCM2 files were installed"
+        return 1
+    fi
+
+    log_success "UCM2 configuration installed ($installed_count files)"
+    return 0
+}
+
+# Restore original UCM2 files from backup
+restore_ucm2() {
+    local ucm2_dest="/usr/share/alsa/ucm2/HDA"
+
+    log_info "Restoring original UCM2 configuration..."
+
+    local ucm2_files=(
+        "HiFi-analog.conf"
+        "HiFi-mic.conf"
+    )
+
+    local restored_count=0
+
+    for file in "${ucm2_files[@]}"; do
+        local dest_file="${ucm2_dest}/${file}"
+        local backup_file="${dest_file}.orig"
+
+        if [[ -f "$backup_file" ]]; then
+            if sudo mv "$backup_file" "$dest_file"; then
+                log_success "Restored: $file"
+                ((restored_count++))
+            else
+                log_error "Failed to restore $file"
+            fi
+        else
+            log_info "No backup found for $file"
+        fi
+    done
+
+    log_info "Restored $restored_count UCM2 files"
+    return 0
+}
+
+# ============================================================================
+# Complete Resource Setup
+# ============================================================================
+
+# Fetch all resources from upstream repository
+fetch_all_resources() {
+    log_section "Fetching All Resources from Upstream"
+
+    # Clone/update repository
+    if ! clone_audio_fix_repo; then
+        return 1
+    fi
+
+    # Verify resources are available
+    local repo_dir="${RESOURCE_CACHE_DIR}/16iax10h-linux-sound-saga"
+
+    log_info "Verifying resources..."
+
+    # Check patches using array glob (more efficient than ls | wc)
+    if [[ -d "${repo_dir}/fix/patches" ]]; then
+        local patches=("${repo_dir}/fix/patches"/*.patch)
+        if [[ -e "${patches[0]}" ]]; then
+            log_success "Patches available: ${#patches[@]}"
+        else
+            log_error "No patch files found"
+            return 1
+        fi
+    else
+        log_error "Patches directory missing"
+        return 1
+    fi
+
+    # Check firmware
+    if [[ -f "${repo_dir}/fix/firmware/aw88399_acf.bin" ]]; then
+        log_success "Firmware available: aw88399_acf.bin"
+    else
+        log_error "Firmware file missing"
+        return 1
+    fi
+
+    # Check UCM2 using array glob
+    if [[ -d "${repo_dir}/fix/ucm2" ]]; then
+        local ucm2_files=("${repo_dir}/fix/ucm2"/*.conf)
+        if [[ -e "${ucm2_files[0]}" ]]; then
+            log_success "UCM2 configs available: ${#ucm2_files[@]}"
+        else
+            log_warn "No UCM2 config files found"
+        fi
+    else
+        log_error "UCM2 directory missing"
+        return 1
+    fi
+
+    log_success "All resources fetched successfully"
+    return 0
+}
+
+# Install all resources (firmware + UCM2)
+install_all_resources() {
+    log_section "Installing Audio Resources"
+
+    local errors=0
+
+    # Install firmware
+    if ! install_firmware; then
+        log_error "Firmware installation failed"
+        ((errors++))
+    fi
+
+    # Install UCM2
+    if ! install_ucm2; then
+        log_warn "UCM2 installation failed (can be done manually later)"
+    fi
+
+    if ((errors > 0)); then
+        return 1
+    fi
+
+    return 0
+}
+
+# Show resource status
+show_resource_status() {
+    local repo_dir="${RESOURCE_CACHE_DIR}/16iax10h-linux-sound-saga"
+
+    echo ""
+    echo "=== Resource Status ==="
+    echo ""
+
+    # Repository
+    echo -n "Upstream Repository: "
+    if [[ -d "$repo_dir/.git" ]]; then
+        local commit
+        commit=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null)
+        echo -e "${GREEN}Cloned${NC} (commit: $commit)"
+    else
+        echo -e "${YELLOW}Not cloned${NC}"
+    fi
+
+    # Firmware
+    echo -n "System Firmware: "
+    if [[ -f "/lib/firmware/aw88399_acf.bin" ]]; then
+        echo -e "${GREEN}Installed${NC}"
+    else
+        echo -e "${RED}Missing${NC}"
+    fi
+
+    # UCM2
+    echo -n "UCM2 Config: "
+    if [[ -f "/usr/share/alsa/ucm2/HDA/HiFi-analog.conf" ]]; then
+        if [[ -f "/usr/share/alsa/ucm2/HDA/HiFi-analog.conf.orig" ]]; then
+            echo -e "${GREEN}Installed (custom)${NC}"
+        else
+            echo -e "${YELLOW}Default${NC}"
+        fi
+    else
+        echo -e "${RED}Missing${NC}"
+    fi
+
+    echo ""
+}

--- a/patch-kernel-fedora/automation/scripts/lib/setup.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/setup.sh
@@ -1,0 +1,555 @@
+#!/bin/bash
+# Setup Library for Kernel Build Environment
+# Handles dependency installation, resource fetching, and MOK verification
+
+# ============================================================================
+# System Checks
+# ============================================================================
+
+# Check if running on Fedora
+check_fedora() {
+    if [[ ! -f /etc/fedora-release ]]; then
+        log_error "This script must run on Fedora"
+        return 1
+    fi
+
+    local fedora_version
+    fedora_version=$(rpm -E %fedora)
+    log_info "Fedora $fedora_version detected"
+    return 0
+}
+
+# Check for required disk space
+check_disk_space() {
+    local work_dir="${WORK_DIR:-$HOME/fedora-kernel-build}"
+    local parent_dir
+    parent_dir=$(dirname "$work_dir")
+    local required_gb=50
+
+    log_info "Checking available disk space..."
+
+    local available_gb
+    available_gb=$(df -BG "$parent_dir" 2>/dev/null | awk 'NR==2 {print int($4)}')
+
+    if [[ -z "$available_gb" ]]; then
+        log_warn "Could not determine available disk space"
+        return 0
+    fi
+
+    if ((available_gb < required_gb)); then
+        log_warn "Low disk space: ${available_gb}GB available, ${required_gb}GB recommended"
+        echo ""
+        echo -n "Continue anyway? [y/N]: "
+        read -r response
+        if [[ ! "$response" =~ ^[Yy]$ ]]; then
+            return 1
+        fi
+    else
+        log_success "Disk space OK: ${available_gb}GB available"
+    fi
+
+    return 0
+}
+
+# ============================================================================
+# Dependency Installation
+# ============================================================================
+
+# Upgrade critical RPM build packages to avoid known bugs
+upgrade_rpm_build_packages() {
+    log_info "Upgrading RPM build packages (required for correct operation)..."
+
+    # These packages must be up-to-date to avoid bugs like "fg: no job control"
+    # which occurs with older versions of python-rpm-macros
+    local critical_packages=(
+        python-rpm-macros
+        python3-rpm-macros
+        rpm-build
+    )
+
+    if sudo dnf upgrade -y "${critical_packages[@]}" 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_success "RPM build packages up-to-date"
+    else
+        log_warn "Could not upgrade some RPM packages (may already be latest)"
+    fi
+}
+
+# Install required packages
+install_build_dependencies() {
+    log_section "Installing Build Dependencies"
+
+    # First, upgrade critical RPM packages to avoid known bugs
+    upgrade_rpm_build_packages
+
+    local required_packages=(
+        # Fedora build tools
+        fedpkg
+        fedora-packager
+        rpm-build
+        koji
+        # General tools
+        git
+        wget
+        curl
+        # Signing tools
+        pesign
+        sbsigntools
+        mokutil
+        openssl
+        nss-tools
+        # Boot tools
+        grubby
+        dracut
+        # Build optimization
+        ccache
+    )
+
+    # Alternative package names for different Fedora versions
+    declare -A package_alternatives=(
+        ["wget"]="wget2-wget"
+    )
+
+    log_info "Checking required packages..."
+
+    local missing_packages=()
+    local installed_count=0
+
+    for pkg in "${required_packages[@]}"; do
+        local pkg_installed=false
+
+        # Check main package name
+        if rpm -q "$pkg" &>/dev/null; then
+            pkg_installed=true
+        # Check alternative package name
+        elif [[ -n "${package_alternatives[$pkg]:-}" ]]; then
+            if rpm -q "${package_alternatives[$pkg]}" &>/dev/null; then
+                pkg_installed=true
+                log_debug "  $pkg (via ${package_alternatives[$pkg]})"
+            fi
+        fi
+
+        if [[ "$pkg_installed" == true ]]; then
+            log_debug "  $pkg"
+            ((installed_count++))
+        else
+            log_info "  $pkg (needs installation)"
+            missing_packages+=("$pkg")
+        fi
+    done
+
+    log_info "Packages: $installed_count installed, ${#missing_packages[@]} missing"
+
+    if ((${#missing_packages[@]} > 0)); then
+        log_info "Installing missing packages..."
+        if sudo dnf install -y "${missing_packages[@]}" 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+            log_success "Build dependencies installed"
+        else
+            log_error "Failed to install some packages"
+            return 1
+        fi
+    else
+        log_success "All build dependencies already installed"
+    fi
+
+    return 0
+}
+
+# Configure pesign for user
+setup_pesign_user() {
+    log_info "Configuring pesign for current user..."
+
+    # Check if user is in pesign users file
+    if ! grep -q "^${USER}$" /etc/pesign/users 2>/dev/null; then
+        log_info "Adding $USER to pesign users..."
+        sudo bash -c "echo $USER >> /etc/pesign/users"
+    fi
+
+    # Run pesign-authorize
+    if sudo /usr/libexec/pesign/pesign-authorize 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_success "Pesign configured for user $USER"
+    else
+        log_warn "Pesign authorization may have issues (often safe to ignore)"
+    fi
+
+    return 0
+}
+
+# ============================================================================
+# Resource Setup
+# ============================================================================
+
+# Setup resources from upstream repository
+setup_resources() {
+    log_section "Resource Setup"
+
+    log_info "Fetching resources from upstream GitHub repository"
+    log_info "Repository: ${AUDIO_FIX_REPO:-$DEFAULT_AUDIO_FIX_REPO}"
+
+    if ! fetch_all_resources; then
+        log_error "Failed to fetch upstream resources"
+        log_info "Please check your internet connection and try again"
+        return 1
+    fi
+
+    log_success "Upstream resources ready"
+    return 0
+}
+
+# ============================================================================
+# MOK/Signing Setup - Simplified Logic
+# ============================================================================
+
+# Get MOK status as a bitmask
+# Returns: 0=all ok, 1=files missing, 2=not enrolled, 4=pesign not configured
+get_mok_status() {
+    local status=0
+    local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+
+    check_mok_files_exist || status=$((status | 1))
+    check_mok_enrolled    || status=$((status | 2))
+
+    if ! check_pesign_cert "$cert_name" || ! check_pesign_key "$cert_name"; then
+        status=$((status | 4))
+    fi
+
+    echo $status
+}
+
+# Handle MOK setup based on status
+handle_mok_setup() {
+    local status=$1
+
+    case $status in
+        0)
+            log_success "MOK signing fully configured - ready to build!"
+            return 0
+            ;;
+        1|3|5|7)
+            # Files missing (possibly with other issues)
+            prompt_create_mok_key || return 1
+            # Recheck after key creation
+            handle_mok_setup "$(get_mok_status)"
+            ;;
+        2|6)
+            # Files exist but not enrolled (possibly pesign issue too)
+            prompt_enroll_mok || return 1
+            ;;
+        4)
+            # Only pesign not configured
+            log_info "Importing MOK into pesign database..."
+            import_to_pesign || return 1
+            log_success "MOK signing setup complete!"
+            ;;
+    esac
+}
+
+# Prompt user to create MOK key
+prompt_create_mok_key() {
+    echo ""
+    log_warn "MOK key files are missing"
+    echo ""
+    echo "Options:"
+    echo "  1) Create new MOK key (recommended for first-time setup)"
+    echo "  2) Specify path to existing MOK key"
+    echo "  3) Continue without signing (ENABLE_SIGNING=false)"
+    echo "  4) Abort and configure manually"
+    echo ""
+    echo -n "Choice [1-4]: "
+    read -r choice
+
+    case "$choice" in
+        1)
+            create_mok_key || return 1
+            ;;
+        2)
+            echo ""
+            echo -n "Enter path to MOK directory: "
+            read -r custom_path
+            if [[ -f "${custom_path}/MOK.priv" && -f "${custom_path}/MOK.der" ]]; then
+                MOK_KEY_DIR="$custom_path"
+                log_success "Using MOK from: $custom_path"
+            else
+                log_error "MOK files not found in: $custom_path"
+                return 1
+            fi
+            ;;
+        3)
+            ENABLE_SIGNING=false
+            log_info "Signing disabled - continuing without signature"
+            return 0
+            ;;
+        *)
+            log_info "Aborting. Configure MOK manually and re-run."
+            return 1
+            ;;
+    esac
+}
+
+# Prompt user to enroll MOK
+prompt_enroll_mok() {
+    echo ""
+    log_warn "MOK key exists but is not enrolled in UEFI"
+
+    # Check if EFI is supported
+    if ! check_efi_support; then
+        log_error "EFI/UEFI is not supported on this system"
+        log_warn ""
+        log_warn "This system appears to be running in:"
+        log_warn "  - Legacy BIOS mode, OR"
+        log_warn "  - A VM without UEFI support, OR"
+        log_warn "  - An environment without EFI variable access"
+        log_warn ""
+        log_info "MOK enrollment is not possible without UEFI support"
+        log_info "You can continue building the kernel without Secure Boot signing"
+        echo ""
+        echo "Options:"
+        echo "  1) Continue without signing (kernel will work on systems with Secure Boot disabled)"
+        echo "  2) Exit script"
+        echo ""
+        echo -n "Choice [1-2]: "
+        read -r choice
+
+        case "$choice" in
+            1)
+                ENABLE_SIGNING=false
+                log_info "Signing disabled - continuing without signature"
+                return 0
+                ;;
+            *)
+                echo ""
+                log_info "Build aborted by user"
+                log_info ""
+                log_info "To use Secure Boot signing, you need to:"
+                log_info "  1. Boot your system in UEFI mode (not Legacy BIOS)"
+                log_info "  2. If using a VM, enable UEFI firmware in VM settings"
+                log_info "  3. Ensure EFI variables are accessible (/sys/firmware/efi/efivars)"
+                log_info ""
+                log_info "To build without signing:"
+                log_info "  - For this build only: ./build-kernel.sh --no-sign"
+                log_info "  - Permanently: set ENABLE_SIGNING=false in config/build.conf"
+                echo ""
+                exit 0
+                ;;
+        esac
+    fi
+
+    log_warn "Enrollment requires a reboot"
+    echo ""
+    echo "Options:"
+    echo "  1) Enroll MOK now (will require reboot before build)"
+    echo "  2) Continue without signing"
+    echo "  3) Abort"
+    echo ""
+    echo -n "Choice [1-3]: "
+    read -r choice
+
+    case "$choice" in
+        1)
+            enroll_mok || return 1
+            save_state "PENDING_MOK_ENROLLMENT"
+            echo ""
+            echo -e "${YELLOW}=======================================${NC}"
+            echo -e "${YELLOW}  REBOOT REQUIRED FOR MOK ENROLLMENT${NC}"
+            echo -e "${YELLOW}=======================================${NC}"
+            echo ""
+            echo "After reboot:"
+            echo "  1. MOK Manager will appear - follow prompts to enroll"
+            echo "  2. Re-run this script to continue the build"
+            echo ""
+            echo -n "Reboot now? [Y/n]: "
+            read -r reboot_choice
+            if [[ ! "$reboot_choice" =~ ^[Nn]$ ]]; then
+                sudo reboot
+            fi
+            exit 0
+            ;;
+        2)
+            ENABLE_SIGNING=false
+            log_info "Signing disabled - continuing without signature"
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Preliminary MOK setup check
+check_mok_setup_preliminary() {
+    log_section "Secure Boot / MOK Preliminary Check"
+
+    # Skip if signing disabled
+    if [[ "${ENABLE_SIGNING:-true}" != true ]]; then
+        log_info "Kernel signing is disabled (ENABLE_SIGNING=false)"
+        log_warn "Built kernel will NOT be signed for Secure Boot"
+        return 0
+    fi
+
+    log_info "Signing is enabled - checking MOK prerequisites..."
+
+    local status
+    status=$(get_mok_status)
+
+    # Log current status
+    if ((status & 1)); then
+        log_info "  MOK key files: missing"
+    else
+        log_info "  MOK key files: present"
+    fi
+
+    if ((status & 2)); then
+        log_info "  MOK enrollment: not enrolled"
+    else
+        log_info "  MOK enrollment: enrolled"
+    fi
+
+    if ((status & 4)); then
+        log_info "  Pesign database: not configured"
+    else
+        log_info "  Pesign database: configured"
+    fi
+
+    # Handle based on status
+    handle_mok_setup "$status"
+}
+
+# ============================================================================
+# Resume from State
+# ============================================================================
+
+# Check and handle saved state (for resuming after reboot)
+check_resume_state() {
+    local saved_state
+    saved_state=$(load_state)
+
+    if [[ -z "$saved_state" ]]; then
+        return 0
+    fi
+
+    log_section "Resuming from Previous State"
+    log_info "Found saved state: $saved_state"
+
+    case "$saved_state" in
+        "PENDING_MOK_ENROLLMENT")
+            log_info "Checking if MOK enrollment completed..."
+            if check_mok_enrolled; then
+                log_success "MOK enrollment successful!"
+                clear_state
+
+                # Continue with pesign setup
+                local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+                if ! check_pesign_cert "$cert_name"; then
+                    log_info "Setting up pesign database..."
+                    if ! import_to_pesign; then
+                        log_error "Failed to setup pesign"
+                        return 1
+                    fi
+                fi
+
+                log_success "Ready to continue with build!"
+                return 0
+            else
+                log_error "MOK enrollment does not appear to have completed"
+                log_info "Did you complete the MOK Manager prompts at boot?"
+                clear_state
+                return 1
+            fi
+            ;;
+        *)
+            log_warn "Unknown state: $saved_state"
+            clear_state
+            return 0
+            ;;
+    esac
+}
+
+# ============================================================================
+# Main Setup Workflow
+# ============================================================================
+
+# Run all setup checks and initialization
+run_setup() {
+    log_section "Pre-flight Setup Checks"
+
+    local setup_failed=false
+
+    # Check for resume state first
+    if ! check_resume_state; then
+        return 1
+    fi
+
+    # Check Fedora
+    if ! check_fedora; then
+        return 1
+    fi
+
+    # Check disk space
+    if ! check_disk_space; then
+        return 1
+    fi
+
+    # Install dependencies
+    if ! install_build_dependencies; then
+        log_error "Failed to install build dependencies"
+        setup_failed=true
+    fi
+
+    # Setup pesign user permissions
+    setup_pesign_user || true
+
+    # Setup resources from upstream
+    if ! setup_resources; then
+        log_error "Failed to setup resources"
+        setup_failed=true
+    fi
+
+    # Check MOK/Signing (preliminary)
+    if ! check_mok_setup_preliminary; then
+        log_error "MOK/Signing setup failed"
+        setup_failed=true
+    fi
+
+    if [[ "$setup_failed" == true ]]; then
+        log_error "Setup checks failed"
+        return 1
+    fi
+
+    log_success "All setup checks passed!"
+    return 0
+}
+
+# Quick setup check (for --check option)
+quick_setup_check() {
+    log_section "Quick Setup Check"
+
+    echo ""
+    echo "=== System ==="
+    echo -n "Fedora: "
+    if check_fedora &>/dev/null; then
+        echo -e "${GREEN}OK${NC} ($(rpm -E %fedora))"
+    else
+        echo -e "${RED}Not Fedora${NC}"
+    fi
+
+    echo ""
+    echo "=== Dependencies ==="
+    local deps=(fedpkg pesign mokutil git)
+    for dep in "${deps[@]}"; do
+        echo -n "$dep: "
+        if command -v "$dep" &>/dev/null; then
+            echo -e "${GREEN}Installed${NC}"
+        else
+            echo -e "${RED}Missing${NC}"
+        fi
+    done
+
+    echo ""
+    echo "=== Resources ==="
+    show_resource_status
+
+    echo ""
+    echo "=== Signing ==="
+    show_mok_status
+
+    return 0
+}

--- a/patch-kernel-fedora/automation/scripts/lib/signing.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/signing.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# Kernel Signing Library for Secure Boot
+# Integrates with mok-manager.sh for complete signing workflow
+
+# ============================================================================
+# Kernel Signing Functions
+# ============================================================================
+
+# Sign kernel with pesign (Fedora native method)
+sign_kernel_pesign() {
+    local kernel_path="$1"
+    local cert_name="${2:-${MOK_CERT_NAME:-MOK Signing Key}}"
+
+    log_section "Kernel Signing"
+
+    # Check if signing prerequisites are met
+    if ! check_signing_prerequisites; then
+        log_error "Signing prerequisites not met"
+        log_info "Run the MOK setup workflow first"
+        return 1
+    fi
+
+    log_success "Certificate '$cert_name' ready in pesign database"
+
+    # Verify kernel file exists
+    if [[ ! -f "$kernel_path" ]]; then
+        log_error "Kernel file not found: $kernel_path"
+        return 1
+    fi
+
+    # Backup original kernel
+    log_info "Backing up unsigned kernel..."
+    if [[ ! -f "${kernel_path}.unsigned" ]]; then
+        sudo cp "$kernel_path" "${kernel_path}.unsigned"
+        log_success "Backup: ${kernel_path}.unsigned"
+    else
+        log_info "Backup already exists, skipping"
+    fi
+
+    # Sign kernel
+    log_info "Signing kernel with pesign..."
+    local signed_path="${kernel_path}.signed"
+
+    if ! sudo pesign -n /etc/pki/pesign -c "$cert_name" \
+        -i "$kernel_path" \
+        -o "$signed_path" \
+        -s 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_error "Kernel signing failed"
+        return 1
+    fi
+
+    log_success "Kernel signed successfully"
+
+    # Replace original with signed version
+    log_info "Replacing unsigned kernel with signed version..."
+    if ! sudo mv "$signed_path" "$kernel_path"; then
+        log_error "Failed to replace kernel with signed version"
+        log_info "Signed version available at: $signed_path"
+        return 1
+    fi
+    log_success "Kernel replaced: $kernel_path"
+
+    # Regenerate GRUB config
+    log_info "Regenerating GRUB configuration..."
+    if sudo grub2-mkconfig -o /boot/grub2/grub.cfg 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+        log_success "GRUB configuration updated"
+    else
+        log_warn "GRUB config regeneration had warnings (usually safe to ignore)"
+    fi
+
+    # Verify signature
+    verify_kernel_signature "$kernel_path"
+
+    return 0
+}
+
+# Verify kernel signature
+verify_kernel_signature() {
+    local kernel_path="$1"
+
+    log_info "Verifying kernel signature..."
+
+    if ! command -v sbverify &>/dev/null; then
+        log_warn "sbverify not installed, skipping verification"
+        return 0
+    fi
+
+    if sudo sbverify --list "$kernel_path" &>/dev/null; then
+        log_success "Kernel signature verified"
+
+        # Show signatures
+        echo ""
+        echo "=== Kernel Signatures ==="
+        sudo sbverify --list "$kernel_path" 2>&1 | grep -E "(signature|Subject|CN=)" | head -20
+        echo ""
+
+        # Count signatures
+        local sig_count
+        sig_count=$(sudo sbverify --list "$kernel_path" 2>&1 | grep -c "^signature" || echo 0)
+        log_info "Total signatures: $sig_count"
+
+        return 0
+    else
+        log_warn "Could not verify signature (sbverify failed)"
+        return 1
+    fi
+}
+
+# ============================================================================
+# Signing Availability Checks
+# ============================================================================
+
+# Check if kernel signing is available (quick check)
+check_signing_available() {
+    local cert_name="${1:-${MOK_CERT_NAME:-MOK Signing Key}}"
+
+    # Check if pesign is installed
+    if ! command -v pesign &>/dev/null; then
+        log_debug "pesign not installed"
+        return 1
+    fi
+
+    # Check if certificate exists
+    if ! sudo certutil -d /etc/pki/pesign -L 2>/dev/null | grep -qF "$cert_name"; then
+        log_debug "Certificate '$cert_name' not found in pesign database"
+        return 1
+    fi
+
+    # Check if private key exists
+    if ! sudo certutil -d /etc/pki/pesign -K 2>/dev/null | grep -qF "$cert_name"; then
+        log_debug "Private key for '$cert_name' not found"
+        return 1
+    fi
+
+    return 0
+}
+
+# ============================================================================
+# Pre-build Signing Verification
+# ============================================================================
+
+# Verify signing setup before starting build
+verify_signing_setup() {
+    local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+
+    log_section "Pre-build Signing Verification"
+
+    if [[ "${ENABLE_SIGNING:-true}" != true ]]; then
+        log_info "Kernel signing is disabled"
+        log_warn "The kernel will NOT be signed for Secure Boot"
+        return 0
+    fi
+
+    log_info "Checking MOK signing prerequisites..."
+
+    # Check 1: MOK key files exist
+    log_info "  Checking MOK key files..."
+    if check_mok_files_exist; then
+        log_success "  MOK key files: OK"
+    else
+        log_error "  MOK key files: MISSING"
+        log_info ""
+        log_info "MOK key files not found. Options:"
+        log_info "  1. Set MOK_KEY_DIR in config to point to your keys"
+        log_info "  2. Run the MOK setup workflow to create new keys"
+        log_info "  3. Set ENABLE_SIGNING=false to skip signing"
+        return 1
+    fi
+
+    # Check 2: MOK enrolled in UEFI
+    log_info "  Checking MOK enrollment in UEFI..."
+    if check_mok_enrolled; then
+        log_success "  MOK enrollment: OK"
+    else
+        log_error "  MOK enrollment: NOT ENROLLED"
+        log_info ""
+        log_info "MOK key is not enrolled in UEFI. This requires a reboot."
+        log_info "Run with --setup-mok to enroll the key."
+        return 1
+    fi
+
+    # Check 3: Pesign database setup
+    log_info "  Checking pesign database..."
+    local has_cert=false
+    local has_key=false
+    check_pesign_cert "$cert_name" && has_cert=true
+    check_pesign_key "$cert_name" && has_key=true
+
+    if [[ "$has_cert" == true && "$has_key" == true ]]; then
+        log_success "  Pesign database: OK"
+    elif [[ "$has_cert" == true || "$has_key" == true ]]; then
+        log_warn "  Pesign database: PARTIAL (cert=$has_cert, key=$has_key)"
+        log_info "  Cleaning up partial configuration and re-importing..."
+        sudo certutil -d /etc/pki/pesign -D -n "$cert_name" 2>/dev/null || true
+
+        if import_to_pesign; then
+            log_success "  Pesign database: OK (just configured)"
+        else
+            log_error "  Failed to configure pesign database"
+            return 1
+        fi
+    else
+        log_warn "  Pesign database: NOT CONFIGURED"
+        log_info ""
+        log_info "MOK key not imported into pesign database."
+        log_info "Attempting to import automatically..."
+
+        if import_to_pesign; then
+            log_success "  Pesign database: OK (just configured)"
+        else
+            log_error "  Failed to configure pesign database"
+            return 1
+        fi
+    fi
+
+    log_success "Signing setup verified - ready to build and sign"
+    return 0
+}
+
+# ============================================================================
+# Interactive Signing Setup
+# ============================================================================
+
+# Interactive setup for signing (called with --setup-mok)
+interactive_signing_setup() {
+    log_section "Interactive MOK Signing Setup"
+
+    # Show current status
+    show_mok_status
+
+    # Check if already configured
+    if check_signing_prerequisites; then
+        log_success "Signing is already fully configured!"
+        echo ""
+        echo -n "Do you want to reconfigure anyway? [y/N]: "
+        read -r response
+        if [[ ! "$response" =~ ^[Yy]$ ]]; then
+            return 0
+        fi
+    fi
+
+    # Run the MOK workflow
+    setup_mok_workflow
+}
+
+# ============================================================================
+# Batch Signing (for multiple kernels)
+# ============================================================================
+
+# Sign all unsigned kernels matching a pattern
+sign_all_kernels() {
+    local pattern="${1:-*audio*}"
+    local cert_name="${MOK_CERT_NAME:-MOK Signing Key}"
+
+    log_section "Batch Kernel Signing"
+
+    if ! check_signing_prerequisites; then
+        log_error "Signing prerequisites not met"
+        return 1
+    fi
+
+    local kernels=()
+    local kernel_pattern="/boot/vmlinuz-${pattern}"
+
+    # Use safe globbing
+    shopt -s nullglob
+    for kernel in $kernel_pattern; do
+        [[ -f "$kernel" ]] && kernels+=("$kernel")
+    done
+    shopt -u nullglob
+
+    if ((${#kernels[@]} == 0)); then
+        log_info "No kernels matching pattern: $pattern"
+        return 0
+    fi
+
+    log_info "Found ${#kernels[@]} kernel(s) to check"
+
+    local signed_count=0
+    for kernel in "${kernels[@]}"; do
+        echo ""
+        log_info "Checking: $(basename "$kernel")"
+
+        # Check if already signed with our key
+        if sudo sbverify --list "$kernel" 2>/dev/null | grep -qF "$cert_name"; then
+            log_info "  Already signed with '$cert_name', skipping"
+            continue
+        fi
+
+        # Sign the kernel
+        if sign_kernel_pesign "$kernel" "$cert_name"; then
+            ((signed_count++))
+        else
+            log_error "  Failed to sign $(basename "$kernel")"
+        fi
+    done
+
+    echo ""
+    log_success "Signed $signed_count kernel(s)"
+
+    return 0
+}

--- a/patch-kernel-fedora/automation/scripts/lib/version-detection.sh
+++ b/patch-kernel-fedora/automation/scripts/lib/version-detection.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Kernel Version Detection Library
+# Handles Fedora release detection and kernel version selection
+
+# Detect current Fedora release
+detect_fedora_release() {
+    if [[ ! -f /etc/fedora-release ]]; then
+        log_error "This system is not Fedora"
+        return 1
+    fi
+
+    local fedora_version
+    fedora_version=$(rpm -E %fedora)
+    echo "f${fedora_version}"
+}
+
+# List available kernel versions from git repository
+# Args: $1 = repo_dir, $2 = max versions per major release (default: 3)
+list_available_kernel_versions() {
+    local repo_dir="$1"
+    local max_per_major="${2:-3}"
+
+    log_debug "Listing available versions in $repo_dir"
+
+    if ! cd "$repo_dir" 2>/dev/null; then
+        log_error "Cannot access repository: $repo_dir"
+        return 1
+    fi
+
+    # Extract all kernel versions from git history
+    local all_versions
+    all_versions=$(git log --oneline --all 2>/dev/null \
+        | grep -oP 'kernel-\K[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' \
+        | sort -Vru)
+
+    if [[ -z "$all_versions" ]]; then
+        log_error "No kernel versions found in git repository"
+        return 1
+    fi
+
+    log_debug "Found $(echo "$all_versions" | wc -l) unique versions"
+
+    # Group by major version (e.g., 6.18, 6.19)
+    local major_versions
+    major_versions=$(echo "$all_versions" | cut -d. -f1-2 | sort -Vru)
+
+    log_debug "Major versions: $(echo "$major_versions" | tr '\n' ' ')"
+
+    # Select top N versions per major release
+    local selected_versions=""
+    local major
+    for major in $major_versions; do
+        local versions
+        versions=$(echo "$all_versions" | grep "^${major}\." | head -n "$max_per_major")
+        selected_versions="${selected_versions}${versions}"$'\n'
+    done
+
+    # Return non-empty lines
+    echo "$selected_versions" | grep -v '^$'
+}
+
+# Interactive menu for kernel version selection
+# Args: $1 = versions (newline-separated), $2 = max display count (default: 20)
+select_kernel_version() {
+    local versions="$1"
+    local max_display="${2:-20}"
+
+    local -a version_array
+    local line
+
+    # Build version array
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        version_array+=("$line")
+    done <<< "$versions"
+
+    local total=${#version_array[@]}
+    local display_count=$((total < max_display ? total : max_display))
+
+    # Display menu (on stderr so stdout can capture selection)
+    {
+        echo ""
+        echo "Available versions (${display_count}/${total}):"
+        echo ""
+
+        local i
+        for ((i = 0; i < display_count; i++)); do
+            printf "  [%2d] kernel-%s\n" "$((i + 1))" "${version_array[$i]}"
+        done
+
+        if ((total > max_display)); then
+            echo "  ... and $((total - max_display)) older versions"
+        fi
+
+        echo ""
+        echo -n "Select version [1-${display_count}]: "
+    } >&2
+
+    local choice
+    read -r choice
+
+    # Validate input
+    if [[ ! "$choice" =~ ^[0-9]+$ ]]; then
+        echo "[ERROR] Invalid input: expected a number" >&2
+        return 1
+    fi
+
+    if ((choice < 1 || choice > display_count)); then
+        echo "[ERROR] Invalid choice: $choice (enter a number between 1 and $display_count)" >&2
+        return 1
+    fi
+
+    # Return selected version (array is 0-indexed)
+    echo "${version_array[$((choice - 1))]}"
+}
+
+# Find git commit hash for a specific kernel version
+# Args: $1 = repo_dir, $2 = version string
+find_commit_for_version() {
+    local repo_dir="$1"
+    local version="$2"
+
+    if ! cd "$repo_dir" 2>/dev/null; then
+        log_error "Cannot access repository: $repo_dir"
+        return 1
+    fi
+
+    local commit
+    commit=$(git log --oneline --all 2>/dev/null \
+        | grep -F "kernel-${version}" \
+        | head -n1 \
+        | awk '{print $1}')
+
+    if [[ -z "$commit" ]]; then
+        log_error "Commit not found for kernel-${version}"
+        return 1
+    fi
+
+    echo "$commit"
+}


### PR DESCRIPTION
This PR adds comprehensive Fedora-specific kernel build documentation and automation tools for users who want to build the patched kernel using Fedora's native build system.

## Documentation
- **FEDORA-BUILD-GUIDE.md**: Complete 12-phase guide covering Fedora kernel build process
- Detailed Secure Boot setup with MOK key management
- Native RPM package generation and installation
- akmods integration for NVIDIA drivers

## Automation
- **build-kernel.sh**: Main automation script with interactive and CLI modes
- Modular architecture with 9 helper libraries:
  - MOK/Secure Boot setup and key enrollment
  - Resource management (patches, firmware, UCM2)
  - Version detection and selection
  - Configuration validation
  - Kernel signing with pesign
  - Archive and cleanup management

## Features

- ✅ Secure Boot compatible (pesign + MOK keys)
- ✅ Native RPM packages for clean install/removal
- ✅ Automated resource fetching from upstream
- ✅ Interactive version selection
- ✅ Build validation and error recovery
- ✅ Configurable via build.conf

## Testing

Tested on Fedora 43 with kernel 6.18.(3, 4, 5, 6, 7) -200, Secure Boot enabled.

## Why Fedora-specific guide?

The existing README covers vanilla kernel builds, but Fedora users benefit from:
- Native package management integration
- Secure Boot support without disabling lockdown
- akmods automatic driver rebuilds
- Distribution-specific patches included

## Related

- Main README updated with link to Fedora guide
- All paths verified and tested
- Scripts follow Fedora best practices