### PR TITLE
fix: remove --color=auto artifact from 6.18 patch diff headers

### DIFF
--- a/fix/patches/16iax10h-audio-linux-6.18.patch
+++ b/fix/patches/16iax10h-audio-linux-6.18.patch
@@ -145,7 +145,7 @@ diff -u -r -N linux-6.18/sound/hda/codecs/side-codecs/Makefile patched/sound/hda
 diff -u -r -N linux-6.18/sound/hda/codecs/side-codecs/aw88399_hda.c patched/sound/hda/codecs/side-codecs/aw88399_hda.c
 --- linux-6.18/sound/hda/codecs/side-codecs/aw88399_hda.c	1970-01-01 02:00:00.000000000 +0200
 +++ patched/sound/hda/codecs/side-codecs/aw88399_hda.c	2025-12-01 08:41:02.325627224 +0200
-@@ -0,0 +1,474 @@
+@@ -0,0 +1,475 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +//
 +// aw88399_hda.c -- AW88399 HDA side codec driver


### PR DESCRIPTION
### Problem

When the 6.18 patch is applied using git apply (as opposed to the standard patch command), the kernel module snd-hda-scodec-aw88399 fails to build with:

`ERROR: modpost: missing MODULE_LICENSE() in sound/hda/codecs/side-codecs/snd-hda-scodec-aw88399.o`
This affects any build system that uses _git apply_ to apply patches, notably Fedora's _rpmbuild_/_fedpkg_ which defines _patch_command='git --work-tree=. apply'_ in _kernel.spec_.

Root causes
Two issues in the 6.18 patch cause _git apply_ to silently drop _MODULE_LICENSE("GPL");_ — the last line of _aw88399_hda.c_:

**1. Non-standard diff headers (_--color=auto_)**
The patch was generated using _diff --color=auto -u -r -N_, likely due to a shell alias. This embeds _'--color=auto'_ literally in the diff headers:


```
-diff '--color=auto' -u -r -N linux-6.18/sound/hda/codecs/...
+diff -u -r -N linux-6.18/sound/hda/codecs/...
```
While the standard _patch_ command tolerates these non-standard headers, _git apply_ does not properly recognize them as file boundaries and silently drops the last line of the preceding hunk.

**2. Incorrect hunk line count after Y9000P merge**
The merge adding Y9000P support (product 83F4, commit ab72a36) inserted a comment line in the _aw88399_hda.c_ hunk without updating the hunk header line count:


```
-@@ -0,0 +1,474 @@
+@@ -0,0 +1,475 @@
```
The hunk declared 474 added lines but contained 475. _git apply_ strictly respects the declared count and stops at line 474, dropping the 475th line: _MODULE_LICENSE("GPL");_.

### Fix
Remove _'--color=auto'_ from all diff headers
Correct the hunk line count: _474_ → _475_
No functional change to the patch content. The 6.19 patch is not affected by either issue.